### PR TITLE
fix: remove npm cache config from release workflow

### DIFF
--- a/.github/workflows/release-vsce.yml
+++ b/.github/workflows/release-vsce.yml
@@ -19,8 +19,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
 
       - name: Install vsce globally
         run: npm install --global @vscode/vsce


### PR DESCRIPTION
Remove cache and cache-dependency-path options from setup-node action to fix "Some specified paths were not resolved, unable to cache dependencies" error during release workflow execution.