### PR TITLE
fix: use npm install instead of npm ci in release workflow

### DIFF
--- a/.github/workflows/release-vsce.yml
+++ b/.github/workflows/release-vsce.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Dependencies & Package Extension
         run: |
-          npm ci
+          npm install
           vsce package
 
       - name: Publish to VS Code Marketplace


### PR DESCRIPTION
Replace `npm ci` with `npm install` since package-lock.json is not committed to the repository. This allows the workflow to run without requiring a lock file.