### PR TITLE
fix: Improve syntax highlighting for multi-line self-closing JSX tags…

### DIFF
--- a/examples/app.jac
+++ b/examples/app.jac
@@ -74,3 +74,12 @@ cl{
         </div>;
     }
 }
+
+cl {
+    def app() -> any {
+        return (
+            <EmailBuddyLayout
+            />
+        );
+    }
+}

--- a/src/__tests__/inspectTokenScopes.test.ts
+++ b/src/__tests__/inspectTokenScopes.test.ts
@@ -284,4 +284,22 @@ describe('inspectTokenScopesHandler - Location Based Tests', () => {
             expectToken(result, 70, 32, 35, 'any', ['support.type.jac']);
         });
     });
+
+    describe('Multi-line Self-closing Tag', () => {
+        test('Multi-line component tag name', () => {
+            // <EmailBuddyLayout
+            // />
+            // app.jac line 81 (approximate, based on append)
+            // We need to find the line number dynamically or assume it's at the end.
+            // Since we appended to app.jac, looking at the previous read, it ended at line 76.
+            // So the new content starts around line 79/80.
+            // line 81: <EmailBuddyLayout
+            expectToken(result, 81, 14, 30, 'EmailBuddyLayout', ['support.class.component.jsx.jac']);
+        });
+
+        test('Multi-line component closing />', () => {
+            // line 82: />
+            expectToken(result, 82, 13, 15, '/>', ['punctuation.definition.tag.end.jsx.jac']);
+        });
+    });
 });

--- a/syntaxes/jac.tmLanguage.json
+++ b/syntaxes/jac.tmLanguage.json
@@ -1,7 +1,9 @@
 {
 	"name": "The Jac Programming Language",
 	"scopeName": "source.jac",
-	"fileTypes": ["jac"],
+	"fileTypes": [
+		"jac"
+	],
 	"patterns": [
 		{
 			"include": "#elements"
@@ -179,7 +181,7 @@
 			"patterns": [
 				{
 					"name": "meta.class.jac",
-					  "begin": "(impl|sem)",
+					"begin": "(impl|sem)",
 					"end": "(?=:|{|\\W)",
 					"beginCaptures": {
 						"1": {
@@ -207,7 +209,7 @@
 			"patterns": [
 				{
 					"name": "meta.function.jac",
-					  "begin": "(?x)\\b(can|with|def|impl|sem)\\b(?=\\s*[[:alpha:]_]\\w*|\\s*({|;|\\(||\\n))",
+					"begin": "(?x)\\b(can|with|def|impl|sem)\\b(?=\\s*[[:alpha:]_]\\w*|\\s*({|;|\\(||\\n))",
 					"end": "(?=\\)|{)|;",
 					"beginCaptures": {
 						"1": {
@@ -432,38 +434,50 @@
 		"jsx-tag-component": {
 			"patterns": [
 				{
-					"comment": "Self-closing component tag",
+					"comment": "Component tag (self-closing or with children)",
 					"name": "meta.jsx.component.jac",
-					"match": "(<)([A-Z][a-zA-Z0-9_$]*)([^>]*)(/>)",
-					"captures": {
-						"1": { "name": "punctuation.definition.tag.begin.jsx.jac" },
-						"2": { "name": "support.class.component.jsx.jac" },
-						"3": { "patterns": [{ "include": "#jsx-tag-attributes" }] },
-						"4": { "name": "punctuation.definition.tag.end.jsx.jac" }
-					}
-				},
-				{
-					"comment": "Component tag with children",
-					"name": "meta.jsx.component.jac",
-					"begin": "(<)([A-Z][a-zA-Z0-9_$]*)(?=[\\s>])",
-					"end": "(</)(\\2)(>)",
+					"begin": "(<)([A-Z][a-zA-Z0-9_$]*)(?=[\\s/>])",
+					"end": "(/>)|(</)(\\2)(>)",
 					"beginCaptures": {
-						"1": { "name": "punctuation.definition.tag.begin.jsx.jac" },
-						"2": { "name": "support.class.component.jsx.jac" }
+						"1": {
+							"name": "punctuation.definition.tag.begin.jsx.jac"
+						},
+						"2": {
+							"name": "support.class.component.jsx.jac"
+						}
 					},
 					"endCaptures": {
-						"1": { "name": "punctuation.definition.tag.begin.jsx.jac" },
-						"2": { "name": "support.class.component.jsx.jac" },
-						"3": { "name": "punctuation.definition.tag.end.jsx.jac" }
+						"1": {
+							"name": "punctuation.definition.tag.end.jsx.jac"
+						},
+						"2": {
+							"name": "punctuation.definition.tag.begin.jsx.jac"
+						},
+						"3": {
+							"name": "support.class.component.jsx.jac"
+						},
+						"4": {
+							"name": "punctuation.definition.tag.end.jsx.jac"
+						}
 					},
 					"patterns": [
 						{
 							"begin": "(>)",
-							"end": "(?=</[A-Z])",
-							"beginCaptures": { "1": { "name": "punctuation.definition.tag.end.jsx.jac" } },
-							"patterns": [{ "include": "#jsx-children" }]
+							"end": "(?=</)",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.definition.tag.end.jsx.jac"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#jsx-children"
+								}
+							]
 						},
-						{ "include": "#jsx-tag-attributes" }
+						{
+							"include": "#jsx-tag-attributes"
+						}
 					]
 				}
 			]
@@ -471,38 +485,50 @@
 		"jsx-tag-html": {
 			"patterns": [
 				{
-					"comment": "Self-closing HTML tag",
+					"comment": "HTML tag (self-closing or with children)",
 					"name": "meta.jsx.html.jac",
-					"match": "(<)([a-z][a-zA-Z0-9_-]*)([^>]*)(/>)",
-					"captures": {
-						"1": { "name": "punctuation.definition.tag.begin.jsx.jac" },
-						"2": { "name": "entity.name.tag.html.jsx.jac" },
-						"3": { "patterns": [{ "include": "#jsx-tag-attributes" }] },
-						"4": { "name": "punctuation.definition.tag.end.jsx.jac" }
-					}
-				},
-				{
-					"comment": "HTML tag with children",
-					"name": "meta.jsx.html.jac",
-					"begin": "(<)([a-z][a-zA-Z0-9_-]*)(?=[\\s>])",
-					"end": "(</)(\\2)(>)",
+					"begin": "(<)([a-z][a-zA-Z0-9_-]*)(?=[\\s/>])",
+					"end": "(/>)|(</)(\\2)(>)",
 					"beginCaptures": {
-						"1": { "name": "punctuation.definition.tag.begin.jsx.jac" },
-						"2": { "name": "entity.name.tag.html.jsx.jac" }
+						"1": {
+							"name": "punctuation.definition.tag.begin.jsx.jac"
+						},
+						"2": {
+							"name": "entity.name.tag.html.jsx.jac"
+						}
 					},
 					"endCaptures": {
-						"1": { "name": "punctuation.definition.tag.begin.jsx.jac" },
-						"2": { "name": "entity.name.tag.html.jsx.jac" },
-						"3": { "name": "punctuation.definition.tag.end.jsx.jac" }
+						"1": {
+							"name": "punctuation.definition.tag.end.jsx.jac"
+						},
+						"2": {
+							"name": "punctuation.definition.tag.begin.jsx.jac"
+						},
+						"3": {
+							"name": "entity.name.tag.html.jsx.jac"
+						},
+						"4": {
+							"name": "punctuation.definition.tag.end.jsx.jac"
+						}
 					},
 					"patterns": [
 						{
 							"begin": "(>)",
-							"end": "(?=</[a-z])",
-							"beginCaptures": { "1": { "name": "punctuation.definition.tag.end.jsx.jac" } },
-							"patterns": [{ "include": "#jsx-children" }]
+							"end": "(?=</)",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.definition.tag.end.jsx.jac"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#jsx-children"
+								}
+							]
 						},
-						{ "include": "#jsx-tag-attributes" }
+						{
+							"include": "#jsx-tag-attributes"
+						}
 					]
 				}
 			]
@@ -953,7 +979,7 @@
 			"patterns": [
 				{
 					"name": "storage.type.function.jac",
-					  "match": "\\b((async\\s+)?\\s*(can|impl|sem|def))\\b"
+					"match": "\\b((async\\s+)?\\s*(can|impl|sem|def))\\b"
 				},
 				{
 					"name": "keyword.control.flow.jac",
@@ -1684,7 +1710,7 @@
 			"patterns": [
 				{
 					"name": "meta.class.jac",
-					  "begin": "(impl|sem)\\s*(?=\\s*[[:alpha:]_]\\w*|\\s*( |:|\\n))",
+					"begin": "(impl|sem)\\s*(?=\\s*[[:alpha:]_]\\w*|\\s*( |:|\\n))",
 					"end": "((?=:| )|;)",
 					"beginCaptures": {
 						"1": {


### PR DESCRIPTION
###  Summary

Fix Jac syntax highlighting for multi-line self-closing JSX-style tags, and add regression coverage.

### Issue
Multi-line self-closing tags (example: `<EmailBuddyLayout ... />` split across lines) were not tokenized correctly, causing incorrect scopes and broken highlighting.

<img width="505" height="234" alt="image" src="https://github.com/user-attachments/assets/2884656d-c548-48de-9952-9b1d587cc1e1" />


### Fix
Update the Jac TextMate grammar to recognize `/>` as a valid tag terminator for both component tags and HTML tags, then add tests and a small example to prevent regressions.

<img width="624" height="264" alt="image" src="https://github.com/user-attachments/assets/b222bed9-1cde-4a15-87ad-6f00bebd7e57" />


### Changes
- `syntaxes/jac.tmLanguage.json`
  - Improved JSX/HTML tag patterns to support self-closing tags (including multi-line forms).
- `src/__tests__/inspectTokenScopes.test.ts`
  - Added tests for multi-line self-closing component tag token scopes.
- `examples/app.jac`
  - Added a minimal example that uses a multi-line self-closing component tag.

### Testing
- Added/updated unit tests for token scope inspection.



