### PR TITLE
Finxing Bugs in syntax highlighter

### DIFF
--- a/src/__tests__/inspectTokenScopes.test.ts
+++ b/src/__tests__/inspectTokenScopes.test.ts
@@ -465,11 +465,9 @@ describe('inspectTokenScopesHandler - Location Based Tests', () => {
             expectToken(result, 96, 17, 20, 'div', ['source.jac', 'meta.jsx.html.jac', 'entity.name.tag.html.jsx.jac']);
         });
 
-        test('JSX comment text as string', () => {
-            // # No parameters - treated as string in JSX
-            const token = getTokenByLocation(result, 97, 1, 28);
-            expect(token).toBeDefined();
-            expect(token!.scopes).toContain('string.unquoted.jsx.jac');
+        test('JSX comment punctuation (#)', () => {
+            // # No parameters - should be treated as a comment in JSX
+            expectToken(result, 97, 13, 14, '#', ['source.jac', 'comment.line.number-sign.jac']);
         });
 
         test('button tag in nested JSX', () => {

--- a/syntaxes/jac.tmLanguage.json
+++ b/syntaxes/jac.tmLanguage.json
@@ -642,6 +642,9 @@
 		"jsx-children": {
 			"patterns": [
 				{
+					"include": "#comments"
+				},
+				{
 					"include": "#jsx-tag-fragment"
 				},
 				{
@@ -660,16 +663,13 @@
 					"include": "#jsx-evaluated-code"
 				},
 				{
-					"include": "#comments"
-				},
-				{
 					"include": "#jsx-text"
 				}
 			]
 		},
 		"jsx-text": {
 			"name": "string.unquoted.jsx.jac",
-			"match": "[^<>{}\n]+"
+			"match": "[^<>{}\n#]+"
 		},
 		"comments": {
 			"patterns": [


### PR DESCRIPTION
This fixes the color issue with comments in JSX tags

<img width="898" height="265" alt="image" src="https://github.com/user-attachments/assets/dbf0781f-bc20-4d89-aeb6-713182c5dc5d" />

