### PR TITLE
fix(grammar): remove dead "#impossible" include (#68)

### DIFF
--- a/syntaxes/jac.tmLanguage.json
+++ b/syntaxes/jac.tmLanguage.json
@@ -1545,11 +1545,7 @@
 			]
 		},
 		"fstring-illegal-multi-brace": {
-			"patterns": [
-				{
-					"include": "#impossible"
-				}
-			]
+			"patterns": []
 		},
 		"f-expression": {
 			"comment": "All valid Python expressions, except comments and line continuation",


### PR DESCRIPTION
Closes #68.

`fstring-illegal-multi-brace` referenced `#impossible` as its only pattern, but no rule with that name is defined anywhere in `syntaxes/jac.tmLanguage.json`. VS Code silently discards the entire containing rule when its includes fail to resolve, cascading upward — so today the rule has no observable presence in VS Code. Stricter consumers like `babi-textmate-demo` raise `KeyError: 'impossible'` and crash on any `.jac` file that exercises the rule (e.g. a single line containing ``f'''``). TextMate 2.0 itself tolerates missing includes; the strict consumer is the outlier, not the spec.

## Fix

Replace the dead include with an explicitly-empty ``patterns`` array so the rule loads cleanly:

```diff
 "fstring-illegal-multi-brace": {
-    "patterns": [
-        {
-            "include": "#impossible"
-        }
-    ]
+    "patterns": []
 }
```

The rule ``fstring-illegal-multi-brace`` is referenced from 4 sites elsewhere in the grammar. With `#impossible` unresolved, VS Code's cascade already silently drops the rule along with those four inclusion sites, so the rule produces zero matches today. Empty ``patterns`` makes that no-op explicit without changing any observable highlighting.

## Why not delete the rule entirely

The rule appears to be half-finished scaffolding from 2023 (commit 1bdccc7, *"I think i have my approach"*) meant to mirror ``fstring-illegal-single-brace``. Deleting the rule would also require removing its 4 inclusions — a bigger surface that mixes two concerns. Per @RedCMD's review, there are also 5 orphan rules in the repository (defined but never referenced): `jsx-tag-in-expression`, `js_style_comment`, `statement`, `fregexp-base-expression`, `comments-base`. Happy to do a separate follow-up PR that removes ``fstring-illegal-multi-brace`` + its 4 inclusions + the 5 orphans if maintainers want the cleanup; left out of this one to keep the diff scoped to #68.

## Verification

- All 211 unit tests pass (``npm run test:unit``) — no highlighting regression on any of the 9 ``.jac`` example fixtures.
- JSON validates.
- Swept the file for broken `#includes`: 223 defined rules, 218 distinct references, **0 missing** after this change.