### PR TITLE
feat: add jac.toml syntax highlighting (jactoml language)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jac Extension
 
-This extension provides support for the [Jac](https://doc.jaseci.org) programming language. It provides syntax highlighting and leverages the LSP to provide a rich editing experience.
+This extension provides support for the [Jac](https://doc.jaseci.org) programming language. It provides syntax highlighting for `.jac` source files and `jac.toml` project manifests, and leverages the LSP to provide a rich editing experience.
 
 # Quick Start
 
@@ -72,7 +72,7 @@ Developer mode enables additional tools for extension development and debugging.
 When enabled, the following features become available:
 
 - **Restart Language Server** - Button in editor title bar to restart the LSP server
-- **Inspect Token Scopes** - Dumps all TextMate token scopes for the current Jac file to help debug syntax highlighting
+- **Inspect Token Scopes** - Dumps all token scopes for the current Jac or jac.toml file to help debug syntax highlighting
 
 # Releasing (Maintainers)
 

--- a/language-configuration.jactoml.json
+++ b/language-configuration.jactoml.json
@@ -1,0 +1,21 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["[", "]"],
+    ["{", "}"]
+  ],
+  "autoClosingPairs": [
+    { "open": "[", "close": "]" },
+    { "open": "{", "close": "}" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    ["[", "]"],
+    ["{", "}"],
+    ["\"", "\""],
+    ["'", "'"]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -140,6 +140,17 @@
           "light": "./assets/file-icon.svg",
           "dark": "./assets/file-icon.svg"
         }
+      },
+      {
+        "id": "jactoml",
+        "aliases": [
+          "Jac TOML",
+          "jactoml"
+        ],
+        "filenames": [
+          "jac.toml"
+        ],
+        "configuration": "./language-configuration.jactoml.json"
       }
     ],
     "grammars": [
@@ -147,6 +158,11 @@
         "language": "jac",
         "scopeName": "source.jac",
         "path": "./syntaxes/jac.tmLanguage.json"
+      },
+      {
+        "language": "jactoml",
+        "scopeName": "source.jactoml",
+        "path": "./syntaxes/jactoml.tmLanguage.json"
       }
     ],
     "debuggers": [
@@ -230,11 +246,12 @@
   "main": "./out/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "compile": "tsc -b && npm run copy-fixtures",
+    "compile": "tsc -b && npm run copy-fixtures && npm run copy-wasm",
     "copy-fixtures": "mkdir -p out/test/fixtures && cp -r src/test/fixtures/* out/test/fixtures/",
+    "copy-wasm": "mkdir -p vendor && cp node_modules/vscode-oniguruma/release/onig.wasm vendor/onig.wasm",
     "build": "vsce",
     "watch": "tsc -b -w",
-    "package": "tsc --noEmit && esbuild src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --minify",
+    "package": "tsc --noEmit && npm run copy-wasm && esbuild src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --minify",
     "deploy": "vsce publish --yarn",
     "vsce-package": "mkdir -p build && vsce package -o build/jac.vsix",
     "test": "npm run test:unit && npm run test:integration",

--- a/src/__tests__/inspectTokenScopes.jactoml.test.ts
+++ b/src/__tests__/inspectTokenScopes.jactoml.test.ts
@@ -1,0 +1,270 @@
+/*
+ * Jest tests for the jactoml grammar via tokenizeContent.
+ * Uses the fixture at src/test/fixtures/sample.jac.toml.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import { tokenizeContent, TokenizeResult, TokenInfo } from '../commands/inspectTokenScopes';
+
+const GRAMMAR_PATH = path.join(process.cwd(), 'syntaxes', 'jactoml.tmLanguage.json');
+const WASM_PATH = path.join(process.cwd(), 'node_modules', 'vscode-oniguruma', 'release', 'onig.wasm');
+const FIXTURE = path.join(process.cwd(), 'src', 'test', 'fixtures', 'sample.jac.toml');
+
+const fixtureContent = fs.readFileSync(FIXTURE, 'utf-8');
+
+function findTokenByText(result: TokenizeResult, line: number, text: string): TokenInfo | undefined {
+    return result.tokens.find(t => t.line === line && t.text === text);
+}
+
+describe('jactoml grammar — sample.jac.toml', () => {
+    let result: TokenizeResult;
+
+    beforeAll(async () => {
+        result = await tokenizeContent(fixtureContent, GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+    });
+
+    test('grammar loads under source.jactoml and produces tokens', () => {
+        expect(result.tokens.length).toBeGreaterThan(0);
+        expect(result.tokens.every(t => t.scopes[0] === 'source.jactoml')).toBe(true);
+    });
+
+    test('[project] table head is captured as one token under jac-known', () => {
+        const tok = findTokenByText(result, 3, 'project');
+        expect(tok).toBeDefined();
+        expect(tok!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+    });
+
+    test('[dependencies.npm]-style headers capture the full dotted path as one jac-known token (not split per segment)', async () => {
+        const r = await tokenizeContent('[dependencies.npm]\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+        const whole = r.tokens.find(t => t.text === 'dependencies.npm');
+        expect(whole).toBeDefined();
+        expect(whole!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+        const justNpm = r.tokens.find(t => t.text === 'npm');
+        expect(justNpm).toBeUndefined();
+    });
+
+    test('[plugins.byllm.model] captures the full dotted path as one jac-known token', () => {
+        const tok = findTokenByText(result, 47, 'plugins.byllm.model');
+        expect(tok).toBeDefined();
+        expect(tok!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+    });
+
+    test('[[plugins.scale.microservices.shared_volumes]] array-of-tables captures full path under jac-known', () => {
+        const tok = findTokenByText(result, 53, 'plugins.scale.microservices.shared_volumes');
+        expect(tok).toBeDefined();
+        expect(tok!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+    });
+
+    test('arbitrary table names like [jac-shadcn] also get the jac-known scope (no allowlist)', async () => {
+        const r = await tokenizeContent('[jac-shadcn]\n[desktop.window]\n[some.deeply.nested.x.y.z]\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+        for (const name of ['jac-shadcn', 'desktop.window', 'some.deeply.nested.x.y.z']) {
+            const tok = r.tokens.find(t => t.text === name);
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+        }
+    });
+
+    test('every LHS key falls back to base taplo property scope (no allowlist)', () => {
+        const tok = findTokenByText(result, 48, 'default_model');
+        expect(tok).toBeDefined();
+        expect(tok!.scopes).toContain('support.type.property-name.toml');
+        expect(tok!.scopes).not.toContain('support.type.property-name.jac-known.jactoml');
+    });
+
+    describe('[plugins.scale.sso.github] block in the fixture (env placeholders in real context)', () => {
+        test('table header captures the full dotted path as one jac-known token', () => {
+            const tok = findTokenByText(result, 57, 'plugins.scale.sso.github');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+        });
+
+        test('all four ${GITHUB_*} placeholders are scoped as variable.other.env.jactoml inside the double-quoted string', () => {
+            const cases: Array<[number, string]> = [
+                [58, '${GITHUB_CLIENT_ID}'],
+                [59, '${GITHUB_CLIENT_SECRET}'],
+                [60, '${GITHUB_PUBLIC_LINK}'],
+                [61, '${GITHUB_APP_SLUG}'],
+            ];
+            for (const [line, text] of cases) {
+                const tok = findTokenByText(result, line, text);
+                expect(tok).toBeDefined();
+                expect(tok!.scopes).toContain('variable.other.env.jactoml');
+                expect(tok!.scopes).toContain('string.quoted.single.basic.line.toml');
+            }
+        });
+
+        test('bare $HOST (no braces) is scoped', () => {
+            const tok = findTokenByText(result, 62, '$HOST');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('variable.other.env.jactoml');
+        });
+
+        test('a string with no placeholder has no env scope', () => {
+            const tok = findTokenByText(result, 63, 'plain literal value');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).not.toContain('variable.other.env.jactoml');
+        });
+
+        test('the LHS keys (client_id, client_secret, public_link, app_slug, host) are recognised as TOML property names by the base grammar', () => {
+            for (const [line, name] of [[58, 'client_id'], [59, 'client_secret'], [60, 'public_link'], [61, 'app_slug'], [62, 'host']] as const) {
+                const tok = findTokenByText(result, line, name);
+                expect(tok).toBeDefined();
+                expect(tok!.scopes).toContain('support.type.property-name.toml');
+            }
+        });
+    });
+
+    describe('incomplete-bracket recovery (mirrors jac grammar -incomplete convention)', () => {
+        test('an unclosed [project line is marked invalid.illegal.table.jactoml', async () => {
+            const r = await tokenizeContent('[project\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const tok = r.tokens.find(t => t.text === '[project');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('invalid.illegal.table.jactoml');
+        });
+
+        test('lines AFTER an unclosed [project keep their proper scoping (no cascade)', async () => {
+            const src = '[project\nname = "jac-ide"\nversion = "1.0.0"\n[dependencies]\nwebsockets = ">=12.0"\n';
+            const r = await tokenizeContent(src, GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+
+            const nameKey = r.tokens.find(t => t.line === 2 && t.text === 'name');
+            expect(nameKey).toBeDefined();
+            expect(nameKey!.scopes).toContain('support.type.property-name.toml');
+            expect(nameKey!.scopes.some(s => s.startsWith('meta.array'))).toBe(false);
+
+            const depsTable = r.tokens.find(t => t.line === 4 && t.text === 'dependencies');
+            expect(depsTable).toBeDefined();
+            expect(depsTable!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+
+            const wsKey = r.tokens.find(t => t.line === 5 && t.text === 'websockets');
+            expect(wsKey).toBeDefined();
+            expect(wsKey!.scopes).toContain('support.type.property-name.toml');
+        });
+
+        test('an unclosed [[plugins.x line is marked invalid and does not cascade', async () => {
+            const src = '[[plugins.x\nname = "foo"\n[dependencies]\n';
+            const r = await tokenizeContent(src, GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+
+            const badHead = r.tokens.find(t => t.line === 1 && t.text === '[[plugins.x');
+            expect(badHead).toBeDefined();
+            expect(badHead!.scopes).toContain('invalid.illegal.table.jactoml');
+
+            const depsTable = r.tokens.find(t => t.line === 3 && t.text === 'dependencies');
+            expect(depsTable).toBeDefined();
+            expect(depsTable!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+        });
+    });
+
+    describe('env-var placeholders inside strings', () => {
+        test('${VAR} inside double-quoted string is scoped as variable.other.env.jactoml', async () => {
+            const r = await tokenizeContent('image_registry = "${ECR_REGISTRY}"\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const tok = r.tokens.find(t => t.text === '${ECR_REGISTRY}');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('variable.other.env.jactoml');
+        });
+
+        test('bare $VAR (no braces) is also scoped', async () => {
+            const r = await tokenizeContent('host = "$HOST"\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const tok = r.tokens.find(t => t.text === '$HOST');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('variable.other.env.jactoml');
+        });
+
+        test('${VAR} inside single-quoted (literal) string is also scoped', async () => {
+            const r = await tokenizeContent("literal = '${LITERAL_VAR}'\n", GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const tok = r.tokens.find(t => t.text === '${LITERAL_VAR}');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('variable.other.env.jactoml');
+        });
+
+        test('mixed text around ${VAR} keeps the surrounding plain string un-scoped', async () => {
+            const r = await tokenizeContent('mixed = "prefix-${MID}-suffix"\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const placeholder = r.tokens.find(t => t.text === '${MID}');
+            expect(placeholder).toBeDefined();
+            expect(placeholder!.scopes).toContain('variable.other.env.jactoml');
+            const prefix = r.tokens.find(t => t.text === 'prefix-');
+            expect(prefix).toBeDefined();
+            expect(prefix!.scopes).not.toContain('variable.other.env.jactoml');
+        });
+
+        test('a plain string with no $ has no env scope', async () => {
+            const r = await tokenizeContent('plain = "no vars here"\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            for (const t of r.tokens) {
+                expect(t.scopes).not.toContain('variable.other.env.jactoml');
+            }
+        });
+    });
+
+    describe('edge cases (TOML stress tests)', () => {
+        test('triple-double-quoted multiline string spans lines and keeps its scope', async () => {
+            const src = 'k = """\nLine 1\nLine 2 with $dollar and "quotes"\n"""\n';
+            const r = await tokenizeContent(src, GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const body = r.tokens.find(t => t.line === 3 && t.text.startsWith('Line 2'));
+            expect(body).toBeDefined();
+            expect(body!.scopes).toContain('string.quoted.triple.basic.block.toml');
+            const dollarVar = r.tokens.find(t => t.line === 3 && t.text === '$dollar');
+            expect(dollarVar).toBeDefined();
+            expect(dollarVar!.scopes).toContain('variable.other.env.jactoml');
+        });
+
+        test('triple-single-quoted literal multiline does NOT process escape sequences', async () => {
+            const src = "regex = '''^\\d{3}-\\d{2}-\\d{4}$'''\n";
+            const r = await tokenizeContent(src, GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const lineToks = r.tokens.filter(t => t.line === 1);
+            const hasLiteralString = lineToks.some(t => t.scopes.includes('string.quoted.triple.literal.block.toml'));
+            expect(hasLiteralString).toBe(true);
+            const hasEscape = lineToks.some(t => t.scopes.includes('constant.character.escape.toml'));
+            expect(hasEscape).toBe(false);
+        });
+
+        test('quoted dotted key "a.b.c" = "..." is a property name, NOT a table header', async () => {
+            const r = await tokenizeContent('"a.b.c" = "this is a key, not a table"\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const lineToks = r.tokens.filter(t => t.line === 1);
+            const isJacKnown = lineToks.some(t => t.scopes.includes('entity.name.tag.jac-known.jactoml'));
+            expect(isJacKnown).toBe(false);
+            const isProperty = lineToks.some(t => t.scopes.includes('support.type.property-name.toml'));
+            expect(isProperty).toBe(true);
+        });
+
+        test('deeply nested table header [a.b.c.d.e.f.g] is one whole-path jac-known token', async () => {
+            const r = await tokenizeContent('[a.b.c.d.e.f.g]\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const tok = r.tokens.find(t => t.text === 'a.b.c.d.e.f.g');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+        });
+
+        test('repeated [[array.of.tables]] headers are each tagged jac-known', async () => {
+            const src = '[[products]]\nname = "A"\n[[products]]\nname = "B"\n  [[products.features]]\n  k = "v"\n';
+            const r = await tokenizeContent(src, GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const headers = r.tokens.filter(t =>
+                t.scopes.includes('entity.name.tag.jac-known.jactoml') &&
+                (t.text === 'products' || t.text === 'products.features')
+            );
+            expect(headers.length).toBe(3);
+        });
+
+        test('inline table { k = "v", n = 42 } scopes keys as meta.table.inline.toml + property name', async () => {
+            const r = await tokenizeContent('inline = { k = "v", n = 42 }\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const k = r.tokens.find(t => t.line === 1 && t.text === 'k' && t.scopes.includes('meta.table.inline.toml'));
+            expect(k).toBeDefined();
+            expect(k!.scopes).toContain('support.type.property-name.toml');
+            const n = r.tokens.find(t => t.line === 1 && t.text === '42' && t.scopes.includes('meta.table.inline.toml'));
+            expect(n).toBeDefined();
+            expect(n!.scopes).toContain('constant.numeric.integer.toml');
+        });
+
+        test('datetime value like 1999-12-31T23:59:59Z is a TOML datetime constant', async () => {
+            const r = await tokenizeContent('dob = 1999-12-31T23:59:59Z\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const tok = r.tokens.find(t => t.text === '1999-12-31T23:59:59Z');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes.some(s => s.includes('time.datetime'))).toBe(true);
+        });
+
+        test('empty table [empty] is still tagged as jac-known', async () => {
+            const r = await tokenizeContent('[empty]\nkey_in_next_section = 1\n', GRAMMAR_PATH, WASM_PATH, 'source.jactoml');
+            const tok = r.tokens.find(t => t.text === 'empty');
+            expect(tok).toBeDefined();
+            expect(tok!.scopes).toContain('entity.name.tag.jac-known.jactoml');
+        });
+    });
+});

--- a/src/commands/inspectTokenScopes.ts
+++ b/src/commands/inspectTokenScopes.ts
@@ -40,22 +40,26 @@ export interface TokenizeResult {
 }
 
 /**
- * Tokenize content using the Jac grammar.
+ * Tokenize content using a TextMate grammar.
+ *
+ * @param scopeName  Top-level scope of the grammar (e.g. 'source.jac', 'source.jactoml').
+ *                   Defaults to 'source.jac' for backwards compatibility.
  */
 export async function tokenizeContent(
     content: string,
     grammarPath: string,
-    wasmPath: string
+    wasmPath: string,
+    scopeName: string = 'source.jac'
 ): Promise<TokenizeResult> {
     await initOnigurumaWithPath(wasmPath);
 
     const grammarData = JSON.parse(fs.readFileSync(grammarPath, 'utf-8'));
     const registry = new vsctm.Registry({
         onigLib: Promise.resolve({ createOnigScanner, createOnigString }),
-        loadGrammar: async (scopeName) => scopeName === 'source.jac' ? grammarData : null,
+        loadGrammar: async (requested) => requested === scopeName ? grammarData : null,
     });
 
-    const grammar = await registry.loadGrammar('source.jac');
+    const grammar = await registry.loadGrammar(scopeName);
     if (!grammar) throw new Error('Failed to load grammar');
 
     const byLocation = new Map<TokenLocation, TokenInfo>();
@@ -83,19 +87,34 @@ export async function tokenizeContent(
     return { byLocation, tokens };
 }
 
+/** Per-language grammar info for the inspector. */
+interface InspectableLanguage {
+    grammarFile: string;
+    scopeName: string;
+}
+
+const INSPECTABLE_LANGUAGES: Record<string, InspectableLanguage> = {
+    jac:     { grammarFile: 'jac.tmLanguage.json',     scopeName: 'source.jac' },
+    jactoml: { grammarFile: 'jactoml.tmLanguage.json', scopeName: 'source.jactoml' },
+};
+
 /**
  * Handler for the Inspect Token Scopes command.
- * Dumps all TextMate token scopes for the current Jac file.
+ * Dumps all TextMate token scopes for the current Jac or Jac TOML file.
  */
 export async function inspectTokenScopesHandler(context: vscode.ExtensionContext): Promise<void> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
-        vscode.window.showErrorMessage('No active editor. Please open a Jac file first.');
+        vscode.window.showErrorMessage('No active editor. Please open a Jac or jac.toml file first.');
         return;
     }
 
-    if (editor.document.languageId !== 'jac') {
-        vscode.window.showErrorMessage('This command only works with Jac files.');
+    const langId = editor.document.languageId;
+    const lang = INSPECTABLE_LANGUAGES[langId];
+    if (!lang) {
+        vscode.window.showErrorMessage(
+            `This command only works with Jac (.jac) or Jac TOML (jac.toml) files. Current language: ${langId}.`
+        );
         return;
     }
 
@@ -103,15 +122,23 @@ export async function inspectTokenScopesHandler(context: vscode.ExtensionContext
     outputChannel.clear();
     outputChannel.show(true);
     outputChannel.appendLine(`Token Scopes for: ${editor.document.fileName}`);
+    outputChannel.appendLine(`Language:         ${langId}  (scope ${lang.scopeName})`);
     outputChannel.appendLine('='.repeat(80));
     outputChannel.appendLine('');
 
     try {
         const wasmPath = path.join(context.extensionPath, 'vendor', 'onig.wasm');
-        const grammarPath = path.join(context.extensionPath, 'syntaxes', 'jac.tmLanguage.json');
+        if (!fs.existsSync(wasmPath)) {
+            throw new Error(
+                `onig.wasm not found at ${wasmPath}. ` +
+                `Run "npm run copy-wasm" (or "npm run compile") before launching the extension.`
+            );
+        }
+
+        const grammarPath = path.join(context.extensionPath, 'syntaxes', lang.grammarFile);
         const text = editor.document.getText();
 
-        const { tokens } = await tokenizeContent(text, grammarPath, wasmPath);
+        const { tokens } = await tokenizeContent(text, grammarPath, wasmPath, lang.scopeName);
 
         for (const token of tokens) {
             outputChannel.appendLine(`${token.text}: ${token.line}:${token.startCol}-${token.endCol}`);

--- a/src/test/fixtures/sample.jac.toml
+++ b/src/test/fixtures/sample.jac.toml
@@ -1,0 +1,63 @@
+# Sample jac.toml exercising every Jac-known table and key.
+
+[project]
+name = "sample-jac-app"
+version = "0.1.0"
+description = "Fixture for jactoml grammar testing"
+entry-point = "main.jac"
+authors = ["Jaseci Labs"]
+license = "MIT"
+keywords = ["jac", "sample"]
+requires-python = ">=3.11"
+
+[project.urls]
+homepage = "https://www.jac-lang.org/"
+
+[project.include]
+data = ["assets/**/*"]
+
+[dependencies]
+jaclang = ">=0.8.0"
+httpx = "^0.27.0"
+
+[dev-dependencies]
+pytest = "*"
+
+[optional-dependencies.tools]
+ruff = "*"
+
+[entrypoints.jac]
+sample = "sample:main"
+
+[test]
+directory = "tests"
+verbose = true
+fail_fast = false
+
+[run]
+topology_index = false
+
+[serve]
+base_route_app = "app"
+
+[check.lint]
+select = ["all"]
+exclude = ["docs/*"]
+
+[plugins.byllm.model]
+default_model = "anthropic/claude-opus-4-7"
+
+[plugins.client.vite]
+plugins = ["tailwindcss()"]
+
+[[plugins.scale.microservices.shared_volumes]]
+name = "shared"
+mount_path = "/mnt/shared"
+
+[plugins.scale.sso.github]
+client_id = "${GITHUB_CLIENT_ID}"
+client_secret = "${GITHUB_CLIENT_SECRET}"
+public_link = "${GITHUB_PUBLIC_LINK}"
+app_slug = "${GITHUB_APP_SLUG}"
+host = "$HOST"
+no_vars_here = "plain literal value"

--- a/syntaxes/jactoml.tmLanguage.json
+++ b/syntaxes/jactoml.tmLanguage.json
@@ -1,0 +1,387 @@
+{
+  "version": "1.0.0",
+  "scopeName": "source.jactoml",
+  "uuid": "8b4e5008-c50d-11ea-a91b-54ee75aeeb97",
+  "patterns": [
+    {
+      "name": "meta.jac.toml.array-table.jactoml",
+      "match": "^\\s*\\[\\[([^\\[\\]]+)\\]\\]\\s*$",
+      "captures": {
+        "1": {
+          "name": "entity.name.tag.jac-known.jactoml"
+        }
+      }
+    },
+    {
+      "name": "meta.jac.toml.table.jactoml",
+      "match": "^\\s*\\[([^\\[\\]]+)\\]\\s*$",
+      "captures": {
+        "1": {
+          "name": "entity.name.tag.jac-known.jactoml"
+        }
+      }
+    },
+    {
+      "include": "#table-incomplete"
+    },
+    {
+      "include": "#commentDirective"
+    },
+    {
+      "include": "#comment"
+    },
+    {
+      "include": "#table"
+    },
+    {
+      "include": "#entryBegin"
+    },
+    {
+      "include": "#value"
+    }
+  ],
+  "repository": {
+    "table-incomplete": {
+      "comment": "A line that starts with [ but is not a well-formed [table] or [[array-table]] header (e.g. user mid-edit). Consume it as a single-line invalid match so it never opens the base TOML array-value context and cascades color loss downstream.",
+      "name": "invalid.illegal.table.jactoml",
+      "match": "^\\s*\\[+[^\\n]*$"
+    },
+    "envPlaceholder": {
+      "comment": "Shell-style env-var placeholders inside strings: ${VAR} or $VAR",
+      "patterns": [
+        {
+          "name": "variable.other.env.jactoml",
+          "match": "\\$\\{[A-Za-z_][A-Za-z0-9_]*\\}"
+        },
+        {
+          "name": "variable.other.env.jactoml",
+          "match": "(?<![\\w$])\\$[A-Za-z_][A-Za-z0-9_]*"
+        }
+      ]
+    },
+    "comment": {
+      "captures": {
+        "1": {
+          "name": "comment.line.number-sign.toml"
+        },
+        "2": {
+          "name": "punctuation.definition.comment.toml"
+        }
+      },
+      "comment": "Comments",
+      "match": "\\s*((#).*)$"
+    },
+    "commentDirective": {
+      "captures": {
+        "1": {
+          "name": "meta.preprocessor.toml"
+        },
+        "2": {
+          "name": "punctuation.definition.meta.preprocessor.toml"
+        }
+      },
+      "comment": "Comments",
+      "match": "\\s*((#):.*)$"
+    },
+    "table": {
+      "patterns": [
+        {
+          "name": "meta.table.toml",
+          "match": "^\\s*(\\[)\\s*((?:(?:(?:[A-Za-z0-9_+-]+)|(?:\"[^\"]+\")|(?:'[^']+'))\\s*\\.?\\s*)+)\\s*(\\])",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.table.toml"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "match": "(?:[A-Za-z0-9_+-]+)|(?:\"[^\"]+\")|(?:'[^']+')",
+                  "name": "support.type.property-name.table.toml"
+                },
+                {
+                  "match": "\\.",
+                  "name": "punctuation.separator.dot.toml"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.definition.table.toml"
+            }
+          }
+        },
+        {
+          "name": "meta.array.table.toml",
+          "match": "^\\s*(\\[\\[)\\s*((?:(?:(?:[A-Za-z0-9_+-]+)|(?:\"[^\"]+\")|(?:'[^']+'))\\s*\\.?\\s*)+)\\s*(\\]\\])",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.array.table.toml"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "match": "(?:[A-Za-z0-9_+-]+)|(?:\"[^\"]+\")|(?:'[^']+')",
+                  "name": "support.type.property-name.array.toml"
+                },
+                {
+                  "match": "\\.",
+                  "name": "punctuation.separator.dot.toml"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.definition.array.table.toml"
+            }
+          }
+        },
+        {
+          "begin": "(\\{)",
+          "end": "(\\})",
+          "name": "meta.table.inline.toml",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.table.inline.toml"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.table.inline.toml"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.table.inline.toml"
+            },
+            {
+              "include": "#entryBegin"
+            },
+            {
+              "include": "#value"
+            }
+          ]
+        }
+      ]
+    },
+    "entryBegin": {
+      "name": "meta.entry.toml",
+      "match": "\\s*((?:(?:(?:[A-Za-z0-9_+-]+)|(?:\"[^\"]+\")|(?:'[^']+'))\\s*\\.?\\s*)+)\\s*(=)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "match": "(?:[A-Za-z0-9_+-]+)|(?:\"[^\"]+\")|(?:'[^']+')",
+              "name": "support.type.property-name.toml"
+            },
+            {
+              "match": "\\.",
+              "name": "punctuation.separator.dot.toml"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.eq.toml"
+        }
+      }
+    },
+    "value": {
+      "patterns": [
+        {
+          "name": "string.quoted.triple.basic.block.toml",
+          "begin": "\"\"\"",
+          "end": "\"\"\"",
+          "patterns": [
+            { "include": "#envPlaceholder" },
+            {
+              "match": "\\\\([btnfr\"\\\\\\n/ ]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+              "name": "constant.character.escape.toml"
+            },
+            {
+              "match": "\\\\[^btnfr/\"\\\\\\n]",
+              "name": "invalid.illegal.escape.toml"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.basic.line.toml",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            { "include": "#envPlaceholder" },
+            {
+              "match": "\\\\([btnfr\"\\\\\\n/ ]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+              "name": "constant.character.escape.toml"
+            },
+            {
+              "match": "\\\\[^btnfr/\"\\\\\\n]",
+              "name": "invalid.illegal.escape.toml"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.triple.literal.block.toml",
+          "begin": "'''",
+          "end": "'''",
+          "patterns": [
+            { "include": "#envPlaceholder" }
+          ]
+        },
+        {
+          "name": "string.quoted.single.literal.line.toml",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            { "include": "#envPlaceholder" }
+          ]
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "constant.other.time.datetime.offset.toml"
+            }
+          },
+          "match": "(?<!\\w)(\\d{4}\\-\\d{2}\\-\\d{2}[T| ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[\\+\\-]\\d{2}:\\d{2}))(?!\\w)"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "constant.other.time.datetime.local.toml"
+            }
+          },
+          "match": "(\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)"
+        },
+        {
+          "name": "constant.other.time.date.toml",
+          "match": "\\d{4}\\-\\d{2}\\-\\d{2}"
+        },
+        {
+          "name": "constant.other.time.time.toml",
+          "match": "\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?"
+        },
+        {
+          "match": "(?<!\\w)(true|false)(?!\\w)",
+          "captures": {
+            "1": {
+              "name": "constant.language.boolean.toml"
+            }
+          }
+        },
+        {
+          "match": "(?<!\\w)([\\+\\-]?(0|([1-9](([0-9]|_[0-9])+)?))(?:(?:\\.([0-9]+))?[eE][\\+\\-]?[1-9]_?[0-9]*|(?:\\.[0-9_]*)))(?!\\w)",
+          "captures": {
+            "1": {
+              "name": "constant.numeric.float.toml"
+            }
+          }
+        },
+        {
+          "match": "(?<!\\w)((?:[\\+\\-]?(0|([1-9](([0-9]|_[0-9])+)?))))(?!\\w)",
+          "captures": {
+            "1": {
+              "name": "constant.numeric.integer.toml"
+            }
+          }
+        },
+        {
+          "match": "(?<!\\w)([\\+\\-]?inf)(?!\\w)",
+          "captures": {
+            "1": {
+              "name": "constant.numeric.inf.toml"
+            }
+          }
+        },
+        {
+          "match": "(?<!\\w)([\\+\\-]?nan)(?!\\w)",
+          "captures": {
+            "1": {
+              "name": "constant.numeric.nan.toml"
+            }
+          }
+        },
+        {
+          "match": "(?<!\\w)((?:0x(([0-9a-fA-F](([0-9a-fA-F]|_[0-9a-fA-F])+)?))))(?!\\w)",
+          "captures": {
+            "1": {
+              "name": "constant.numeric.hex.toml"
+            }
+          }
+        },
+        {
+          "match": "(?<!\\w)(0o[0-7](_?[0-7])*)(?!\\w)",
+          "captures": {
+            "1": {
+              "name": "constant.numeric.oct.toml"
+            }
+          }
+        },
+        {
+          "match": "(?<!\\w)(0b[01](_?[01])*)(?!\\w)",
+          "captures": {
+            "1": {
+              "name": "constant.numeric.bin.toml"
+            }
+          }
+        },
+        {
+          "name": "meta.array.toml",
+          "begin": "(?<!\\w)(\\[)\\s*",
+          "end": "\\s*(\\])(?!\\w)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.array.toml"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.array.toml"
+            }
+          },
+          "patterns": [
+            {
+              "match": ",",
+              "name": "punctuation.separator.array.toml"
+            },
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#value"
+            }
+          ]
+        },
+        {
+          "begin": "(\\{)",
+          "end": "(\\})",
+          "name": "meta.table.inline.toml",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.table.inline.toml"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.table.inline.toml"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.table.inline.toml"
+            },
+            {
+              "include": "#entryBegin"
+            },
+            {
+              "include": "#value"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated `jactoml` language to the extension so every `jac.toml` project manifest in the Jaseci ecosystem (jaclang, jacBuilder, jac-scale, jac-byllm, jac-mcp, jac-super, jac-client, jaseci-package, docs, …) gets proper highlighting out of the box, with no dependency on another TOML extension.

- New language `jactoml` registered with **exact filename match** on `jac.toml` (won't touch `pyproject.toml`, `Cargo.toml`, etc.).
- A small Jac semantic layer:
  - **Every** table header `[...]` and `[[...]]` (any name, any dotted depth) is captured as one token under `entity.name.tag.jac-known.jactoml`, so the entire header renders in a single uniform color — no allowlist, no per-segment splitting (`[dependencies.npm]`, `[plugins.scale.sso.google]`, `[[plugins.scale.microservices.shared_volumes]]` all behave identically).
  - Incomplete `[table` headers (mid-edit) are tagged `invalid.illegal.table.jactoml` on the offending line only — no cascading color loss to lines below.
  - Shell-style env placeholders (`${ECR_REGISTRY}`, `$HOST`) inside any string flavor are scoped as `variable.other.env.jactoml`.
- Language configuration (`#` comments, bracket pairs, autoclose, surround).
- README updated to mention `jac.toml` support.

### Bonus fix: `Jac: Inspect Token Scopes` was broken

Existing command threw `ENOENT: .../vendor/onig.wasm` on every published install because the wasm was never copied out of `node_modules` (which `.vscodeignore` excludes from the .vsix). Fixed by:

- New `copy-wasm` npm script (run from both `compile` and `package`) that copies `node_modules/vscode-oniguruma/release/onig.wasm` into `vendor/onig.wasm`. `vendor/` is gitignored, so the wasm is a build artifact, not a committed binary.
- Inspector handler generalized to recognize **both** `jac` (`.jac`) and `jactoml` (`jac.toml`) languages, picking the correct grammar and scope automatically.
- Clearer runtime error if the wasm is missing.