### PR TITLE
feat: add syntaxHighlightingOnly setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable developer mode to use experimental language server features"
+        },
+        "jaclang-extension.syntaxHighlightingOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable syntax highlighting only. Disables the Jac language server and environment selection (no type checking, diagnostics, go-to-definition, hover, or completion)."
         }
       }
     },
@@ -91,30 +96,30 @@
         {
           "command": "jaclang-extension.runCurrentFile",
           "group": "navigation@0",
-          "when": "resourceLangId == jac"
+          "when": "resourceLangId == jac && !config.jaclang-extension.syntaxHighlightingOnly"
         },
         {
           "command": "jaclang-extension.debugCurrentFile",
           "group": "navigation@1",
-          "when": "resourceLangId == jac"
+          "when": "resourceLangId == jac && !config.jaclang-extension.syntaxHighlightingOnly"
         }
       ],
       "editor/title": [
         {
           "command": "jaclang-extension.restartLanguageServer",
           "group": "navigation@98",
-          "when": "resourceLangId == jac && config.jaclang-extension.developerMode"
+          "when": "resourceLangId == jac && config.jaclang-extension.developerMode && !config.jaclang-extension.syntaxHighlightingOnly"
         },
         {
           "command": "jaclang-extension.serveCurrentFile",
           "group": "navigation@99",
-          "when": "resourceLangId == jac && config.jaclang-extension.showServeCommand"
+          "when": "resourceLangId == jac && config.jaclang-extension.showServeCommand && !config.jaclang-extension.syntaxHighlightingOnly"
         }
       ],
       "editor/context": [
         {
           "command": "jac.lintfixFormat",
-          "when": "resourceLangId == jac",
+          "when": "resourceLangId == jac && !config.jaclang-extension.syntaxHighlightingOnly",
           "group": "1_modification"
         }
       ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,12 @@ export function getEnvManager(): EnvManager | undefined {
     return envManager;
 }
 
+export function isSyntaxHighlightingOnly(): boolean {
+  return vscode.workspace
+    .getConfiguration("jaclang-extension")
+    .get<boolean>("syntaxHighlightingOnly", false);
+}
+
 // Create and start LSP Manager if not already running
 export async function createAndStartLsp(
   envManager: EnvManager,
@@ -37,18 +43,24 @@ export async function activate(context: vscode.ExtensionContext) {
   try {
     envManager = new EnvManager(context);
     registerAllCommands(context, envManager);
-    await envManager.init();
+
+    const highlightOnly = isSyntaxHighlightingOnly();
+    if (!highlightOnly) {
+      await envManager.init();
+    }
 
     setupVisualDebuggerWebview(context);
 
-    const jacPath = envManager.getJacPath();
-    const isJacAvailable = await validateJacExecutable(jacPath); // Check if Jac is available before starting LSP
+    if (!highlightOnly) {
+      const jacPath = envManager.getJacPath();
+      const isJacAvailable = await validateJacExecutable(jacPath); // Check if Jac is available before starting LSP
 
-    if (isJacAvailable) {
-      try {
-        await createAndStartLsp(envManager, context);
-      } catch (error) {
-        console.error("LSP failed to start during activation:", error);
+      if (isJacAvailable) {
+        try {
+          await createAndStartLsp(envManager, context);
+        } catch (error) {
+          console.error("LSP failed to start during activation:", error);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Adds a new `jaclang-extension.syntaxHighlightingOnly` boolean setting (default `false`). When enabled:

- `EnvManager.init()` is skipped.
- The Jac language server is not started.
- Jac-specific menu/context commands (run, debug, restart language server, serve, lintfix) are hidden via `when` clauses.

This is useful for users who only want syntax highlighting and either don't have a Jac runtime installed or don't want the LSP to run for performance reasons.

## Changes

- `package.json` — new config setting + `!config.jaclang-extension.syntaxHighlightingOnly` gating on 5 menu entries.
- `src/extension.ts` — new `isSyntaxHighlightingOnly()` helper; `activate()` skips `envManager.init()` and `createAndStartLsp()` when the flag is on.

## Test plan

- [ ] Install the extension with `syntaxHighlightingOnly: true` and confirm: no LSP starts, no env manager popup, Jac files still highlight, run/debug/serve/lintfix commands not in menus.
- [ ] Install with default (`syntaxHighlightingOnly: false`) and confirm: LSP starts as before, all commands available.
- [ ] Toggle the setting at runtime (requires reload) and confirm the change takes effect.