### PR TITLE
feat: highlight skip and awaiting slot keywords

### DIFF
--- a/examples/slot_keywords.jac
+++ b/examples/slot_keywords.jac
@@ -1,0 +1,41 @@
+"""JSX-slot keywords: `skip;` (KW_SKIP) and `try {} awaiting {}` (KW_AWAITING)."""
+
+obj UserCard {
+    has name: str;
+}
+
+def:pub Skeleton -> JsxElement {
+    return <p>Loading…</p>;
+}
+
+def:pub CardView(user: UserCard) -> JsxElement {
+    return <h2>{user.name}</h2>;
+}
+
+cl {
+    def:pub TasksPanel(tasks: list, loading: bool) -> JsxElement {
+        return
+            <div>
+                {if loading {
+                    <p>Loading...</p>
+                    skip;
+                }if len(tasks) == 0 {
+                    <p>Empty</p>
+                    skip;
+                }for t in tasks {
+                    <TaskItem task={t}/>
+                }}
+            </div>;
+    }
+
+    def:pub UserPanel(user: UserCard) -> JsxElement {
+        return
+            <section>
+                {try {
+                    <CardView user={user}/>
+                } awaiting {
+                    <Skeleton/>
+                }}
+            </section>;
+    }
+}

--- a/src/__tests__/inspectTokenScopes.test.ts
+++ b/src/__tests__/inspectTokenScopes.test.ts
@@ -41,6 +41,7 @@ const accessModContent    = fs.readFileSync(path.join(EXAMPLES_DIR, 'access_modi
 const lambdaFstringContent = fs.readFileSync(path.join(EXAMPLES_DIR, 'lambda_fstring.jac'), 'utf-8');
 const overrideFnContent   = fs.readFileSync(path.join(EXAMPLES_DIR, 'override_fn.jac'), 'utf-8');
 const propAccessorsContent = fs.readFileSync(path.join(EXAMPLES_DIR, 'property_accessors.jac'), 'utf-8');
+const slotKeywordsContent = fs.readFileSync(path.join(EXAMPLES_DIR, 'slot_keywords.jac'), 'utf-8');
 
 /**
  * Helper to assert a token has expected text and contains expected scopes
@@ -1114,5 +1115,31 @@ describe('property_accessors.jac', () => {
 
     test('signature-only `deleter;` (line 29)', () => {
         expectToken(result, 29, 9, 16, 'deleter', ['source.jac', 'meta.function.accessor.jac', 'storage.type.function.jac']);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// slot_keywords.jac — `skip;` (KW_SKIP) and `try {} awaiting {}` (KW_AWAITING)
+// ---------------------------------------------------------------------------
+describe('slot_keywords.jac', () => {
+    let result: TokenizeResult;
+    const flow = ['source.jac', 'keyword.control.flow.jac'];
+
+    beforeAll(async () => {
+        result = await tokenizeContent(slotKeywordsContent, GRAMMAR_PATH, WASM_PATH);
+    });
+
+    test('skip keyword is control flow (lines 21, 24)', () => {
+        expectToken(result, 21, 21, 25, 'skip', flow);
+        expectToken(result, 24, 21, 25, 'skip', flow);
+    });
+
+    test('for keyword in slot after skip (line 25)', () => {
+        expectToken(result, 25, 18, 21, 'for', flow);
+    });
+
+    test('try / awaiting clause (lines 34, 36)', () => {
+        expectToken(result, 34, 18, 21, 'try', flow);
+        expectToken(result, 36, 19, 27, 'awaiting', flow);
     });
 });

--- a/syntaxes/jac.tmLanguage.json
+++ b/syntaxes/jac.tmLanguage.json
@@ -995,7 +995,7 @@
 				},
 				{
 					"name": "keyword.control.flow.jac",
-					"match": "(?x)\n  \\b(?<!\\.)(\n    async | await | continue | entry | exit | del | assert | break | finally | for\n    | from | elif | else | if | except | pass | raise\n    | return | report | try | while | with | to | by | spawn | ignore | visit | disengage | lambda\n  )\\b\n"
+					"match": "(?x)\n  \\b(?<!\\.)(\n    async | await | awaiting | continue | entry | exit | del | assert | break | finally | for\n    | from | elif | else | if | except | pass | raise\n    | return | report | try | while | with | to | by | spawn | ignore | visit | disengage | skip | lambda\n  )\\b\n"
 				},
 				{
 					"name": "storage.modifier.declaration.jac",


### PR DESCRIPTION
## Summary

Adds the two JSX-slot control keywords recently introduced in jaclang to the syntax highlighter:

- **`skip`** (`KW_SKIP`) — the canonical JSX-slot early-exit, from [jaseci#6083](https://github.com/jaseci-labs/jaseci/pull/6083).
- **`awaiting`** (`KW_AWAITING`) — the `try { ... } awaiting { ... }` clause, from [jaseci#6063](https://github.com/jaseci-labs/jaseci/pull/6063).

<img width="760" height="968" alt="image" src="https://github.com/user-attachments/assets/ab9a0c76-c66d-46cf-9ae7-40d28abd25a0" />
