### PR TITLE
fix: correct -> scoping for return annotations and graph traversal operators

### DIFF
--- a/examples/arrow_repro.jac
+++ b/examples/arrow_repro.jac
@@ -1,0 +1,48 @@
+obj ItemView {
+    has id: str,
+        name: str;
+}
+
+obj CollectionView {
+    has items: list[ItemView];
+}
+
+# Node with complex method bodies (mirrors Profile node in test.jac)
+node ComplexNode {
+    has username: str = "",
+        bio: str = "";
+
+    def to_simple_view -> ItemView {
+        return ItemView(id=jid(self), name=self.username);
+    }
+
+    def to_complex_view -> CollectionView {
+        items = [p.to_simple_view() for p in [self-->[?:ComplexNode]]];
+        items.sort(key=lambda t: ItemView : t.name, reverse=True);
+        return CollectionView(
+            items=items
+        );
+    }
+}
+
+# This node's -> should NOT be red — but fails if context leaks from above
+node ProblemNode {
+    has content: str = "",
+        likes: list[str] = [],
+        comments: list[dict[str, str]] = [];
+
+    def to_view -> ItemView {
+        return ItemView(id=jid(self), name=self.content);
+    }
+}
+
+# Graph traversal -> operators — these should NOT be red either
+node TraversalNode {
+    has value: str = "";
+
+    def connected_count -> int {
+        # -> inside len([edge ...]) is a graph operator, not an annotation
+        is_linked: bool = len([self]) > 0 and len([edge self->[?:TraversalNode]]) > 0;
+        return len([self-->[?:TraversalNode]]);
+    }
+}

--- a/src/__tests__/inspectTokenScopes.test.ts
+++ b/src/__tests__/inspectTokenScopes.test.ts
@@ -42,6 +42,7 @@ const lambdaFstringContent = fs.readFileSync(path.join(EXAMPLES_DIR, 'lambda_fst
 const overrideFnContent   = fs.readFileSync(path.join(EXAMPLES_DIR, 'override_fn.jac'), 'utf-8');
 const propAccessorsContent = fs.readFileSync(path.join(EXAMPLES_DIR, 'property_accessors.jac'), 'utf-8');
 const slotKeywordsContent = fs.readFileSync(path.join(EXAMPLES_DIR, 'slot_keywords.jac'), 'utf-8');
+const arrowReproContent   = fs.readFileSync(path.join(EXAMPLES_DIR, 'arrow_repro.jac'), 'utf-8');
 
 /**
  * Helper to assert a token has expected text and contains expected scopes
@@ -1141,5 +1142,54 @@ describe('slot_keywords.jac', () => {
     test('try / awaiting clause (lines 34, 36)', () => {
         expectToken(result, 34, 18, 21, 'try', flow);
         expectToken(result, 36, 19, 27, 'awaiting', flow);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// arrow_repro.jac — return-annotation -> and graph-traversal -> / --> / <-
+// ---------------------------------------------------------------------------
+describe('arrow_repro.jac', () => {
+    let result: TokenizeResult;
+    const anno  = ['source.jac', 'meta.function.jac', 'punctuation.separator.annotation.result.jac'];
+    const graph = ['source.jac', 'keyword.operator.graph.jac'];
+
+    beforeAll(async () => {
+        result = await tokenizeContent(arrowReproContent, GRAMMAR_PATH, WASM_PATH);
+    });
+
+    describe('return-type -> annotations are correctly scoped', () => {
+        test('-> in def to_simple_view (line 15)', () => {
+            // def to_simple_view -> ItemView {
+            expectToken(result, 15, 24, 26, '->', anno);
+        });
+
+        test('-> in def to_complex_view (line 19)', () => {
+            // def to_complex_view -> CollectionView {
+            expectToken(result, 19, 25, 27, '->', anno);
+        });
+
+        test('-> in def to_view after sort(key=lambda…) — regression: context must not leak (line 34)', () => {
+            // sort(key=lambda t: ItemView : t.name, reverse=True) on line 21 used to
+            // leave function-arguments open, causing -> on line 34 to be invalid.
+            // def to_view -> ItemView {
+            expectToken(result, 34, 17, 19, '->', anno);
+        });
+
+        test('-> in def connected_count (line 43)', () => {
+            // def connected_count -> int {
+            expectToken(result, 43, 25, 27, '->', anno);
+        });
+    });
+
+    describe('graph traversal -> and --> are keyword.operator.graph.jac, not invalid', () => {
+        test('-> inside len([edge self->...]) is graph operator (line 45)', () => {
+            // is_linked: bool = len([self]) > 0 and len([edge self->[?:TraversalNode]]) > 0;
+            expectToken(result, 45, 61, 63, '->', graph);
+        });
+
+        test('--> inside len([self-->...]) is graph operator (line 46)', () => {
+            // return len([self-->[?:TraversalNode]]);
+            expectToken(result, 46, 25, 28, '-->', graph);
+        });
     });
 });

--- a/syntaxes/jac.tmLanguage.json
+++ b/syntaxes/jac.tmLanguage.json
@@ -264,6 +264,9 @@
 							"include": "#arch-var-reference"
 						},
 						{
+							"include": "#return-annotation"
+						},
+						{
 							"name": "entity.name.function.jac",
 							"match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\b\n"
 						}
@@ -378,6 +381,9 @@
 				},
 				{
 					"include": "#jsx"
+				},
+				{
+					"include": "#jac-graph-operator"
 				},
 				{
 					"include": "#literal"
@@ -1024,6 +1030,9 @@
 			"patterns": [
 				{
 					"include": "#jsx"
+				},
+				{
+					"include": "#jac-graph-operator"
 				},
 				{
 					"include": "#illegal-anno"
@@ -1945,7 +1954,7 @@
 		},
 		"lambda-parameter-with-default": {
 			"begin": "(?x)\n  \\b\n  ([[:alpha:]_]\\w*) \\s* (=)\n",
-			"end": "(,)|(?=->|{|$)",
+			"end": "(,)|(?=->|[{)}]|$)",
 			"beginCaptures": {
 				"1": {
 					"name": "variable.parameter.function.language.jac"
@@ -2158,7 +2167,7 @@
 		},
 		"return-annotation": {
 			"begin": "(->)",
-			"end": "(?=:|{)",
+			"end": "(?=:|{|;)",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.separator.annotation.result.jac"
@@ -2527,6 +2536,10 @@
 			"comment": "It's illegal to name class or function \"True\"",
 			"name": "keyword.illegal.name.jac",
 			"match": "\\b(True|False|None)\\b"
+		},
+		"jac-graph-operator": {
+			"name": "keyword.operator.graph.jac",
+			"match": "\\+\\+>|<\\+\\+|-->|<--|->|<-|\\+>|<\\+"
 		},
 		"illegal-anno": {
 			"name": "invalid.illegal.annotation.jac",


### PR DESCRIPTION
## What's fixed

Four places where `->` was incorrectly highlighted red in `.jac` files.

| Bug | What was happening | Fix |
|-----|--------------------|-----|
| **Lambda context leak** | `sort(key=lambda t: TweetView : t.created_at, reverse=True)` — the grammar treated `reverse` as another lambda parameter and swallowed the closing `)` of `sort()`, leaving the `function-arguments` context open for all following lines. The next `def to_view -> TweetView` was parsed as if it were inside a call, making `->` appear invalid. | Added `)` to the end condition of `lambda-parameter-with-default` so it exits correctly when the outer call closes. |
| **Return annotation not handled** | The `ability` rule (which matches `def`, `can`, `with`) had no explicit pattern for `->`, so return type arrows fell through to the catch-all `illegal-anno` rule and were marked red. | Added `#return-annotation` to the `ability` pattern list so `->` in return-type position gets the correct `punctuation.separator.annotation.result.jac` scope. |
| **Semicolon declaration bleed** | `return-annotation` ended on `:` or `{` — fine for function bodies, but `def foo -> Type;` (signature only, no body) left the context unclosed, bleeding into whatever came next. | Extended the end pattern to also stop at `;`. |
| **Graph operators marked invalid** | Jac uses `->` and `-->` as graph edge operators inside expressions like `[edge self->[?:Node]]`. Since `->` only had `illegal-anno` in expression context, these legitimate operators were always highlighted red. | Added a `jac-graph-operator` rule matching `-->`, `<--`, `->`, `<-`, `+>`, `<+` with scope `keyword.operator.graph.jac`, placed before `illegal-anno` in `expression-bare`. |

---

<img width="1045" height="491" alt="image" src="https://github.com/user-attachments/assets/65d63cb3-aa81-4fcb-bff6-9a47db1a1148" />