### PR TITLE
fix: support new Zig-based binary jac install (replaces pip install)

### DIFF
--- a/src/__tests__/env_test.test.ts
+++ b/src/__tests__/env_test.test.ts
@@ -1,10 +1,17 @@
 import { EnvManager } from '../environment/manager';
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as envDetection from '../utils/envDetection';
 import * as envVersion from '../utils/envVersion';
 import { getLspManager, createAndStartLsp } from '../extension';
 
 // ── Module Mocks ──────────────────────────────────────────────────────────────
+
+// Keep real fs behavior, but make existsSync overridable for getPythonPath tests.
+jest.mock('fs', () => ({
+    ...jest.requireActual('fs'),
+    existsSync: jest.fn(jest.requireActual('fs').existsSync),
+}));
 
 jest.mock('vscode-languageclient/node', () => ({
     LanguageClient: class {
@@ -415,12 +422,21 @@ describe('EnvManager', () => {
     });
 
     describe('getPythonPath()', () => {
-        test('returns python in the same directory as the configured jac executable', () => {
+        test('returns the sibling python when it exists (venv/conda install)', () => {
+            (fs.existsSync as jest.Mock).mockReturnValue(true);
             (envManager as any).jacPath = '/home/user/.venv/bin/jac';
             const expected = process.platform === 'win32'
                 ? '/home/user/.venv/bin/python.exe'
                 : '/home/user/.venv/bin/python';
             expect(envManager.getPythonPath()).toBe(expected);
+            (fs.existsSync as jest.Mock).mockReset();
+        });
+
+        test('returns bare python when no sibling exists (single binary install)', () => {
+            (fs.existsSync as jest.Mock).mockReturnValue(false);
+            (envManager as any).jacPath = '/home/user/.local/bin/jac';
+            expect(envManager.getPythonPath()).toBe(process.platform === 'win32' ? 'python.exe' : 'python');
+            (fs.existsSync as jest.Mock).mockReset();
         });
 
         test('falls back to the platform default when no path is configured', () => {

--- a/src/environment/manager.ts
+++ b/src/environment/manager.ts
@@ -90,12 +90,19 @@ export class EnvManager {
     }
 
     getPythonPath(): string {
+        const pythonExe = process.platform === 'win32' ? 'python.exe' : 'python';
         if (this.jacPath) {
-            const jacDir = path.dirname(this.jacPath);
-            const pythonExe = process.platform === 'win32' ? 'python.exe' : 'python';
-            return path.join(jacDir, pythonExe);
+            // Binary install: Python is embedded inside jac — no sibling python in bin/.
+            // Applies to ~/.local/bin/jac (curl installer) and /usr/local/bin/jac.
+            const isBinaryInstall =
+                this.jacPath.includes(`${path.sep}.local${path.sep}bin${path.sep}`) ||
+                this.jacPath === '/usr/local/bin/jac';
+            if (isBinaryInstall) { return pythonExe; }
+
+            // Legacy venv (pip install jaclang): python sits next to jac in bin/.
+            return path.join(path.dirname(this.jacPath), pythonExe);
         }
-        return process.platform === 'win32' ? 'python.exe' : 'python';
+        return pythonExe;
     }
 
     getStatusBar(): vscode.StatusBarItem {
@@ -253,7 +260,7 @@ export class EnvManager {
         const typeLabel = envType.charAt(0).toUpperCase() + envType.slice(1);
 
         const versionStr = version ? `Jac ${version}` : 'Jac';
-        const namePart = envName ? ` (${envName})` : '';
+        const namePart = envType === 'global' ? '' : envName ? ` (${envName})` : '';
         const label = `${isActive ? '$(check) ' : ''}${versionStr}${namePart}`;
         const description = `${this.formatPath(envPath)}  ·  ${typeLabel}`;
 

--- a/src/environment/manager.ts
+++ b/src/environment/manager.ts
@@ -93,10 +93,8 @@ export class EnvManager {
         const pythonExe = process.platform === 'win32' ? 'python.exe' : 'python';
         if (this.jacPath) {
             // Binary install: Python is embedded inside jac — no sibling python in bin/.
-            // Applies to ~/.local/bin/jac (curl installer) and /usr/local/bin/jac.
-            const isBinaryInstall =
-                this.jacPath.includes(`${path.sep}.local${path.sep}bin${path.sep}`) ||
-                this.jacPath === '/usr/local/bin/jac';
+            // Applies to ~/.local/bin/jac (curl installer default location).
+            const isBinaryInstall = this.jacPath.includes(`${path.sep}.local${path.sep}bin${path.sep}`);
             if (isBinaryInstall) { return pythonExe; }
 
             // Legacy venv (pip install jaclang): python sits next to jac in bin/.

--- a/src/environment/manager.ts
+++ b/src/environment/manager.ts
@@ -92,12 +92,11 @@ export class EnvManager {
     getPythonPath(): string {
         const pythonExe = process.platform === 'win32' ? 'python.exe' : 'python';
         if (this.jacPath) {
-            // Binary install: Python is embedded inside jac — no sibling python in bin/.
-            // Applies to ~/.local/bin/jac (curl installer default location).
+            // ~/.local/bin/jac is the binary installer — Python is embedded, no sibling in bin/.
             const isBinaryInstall = this.jacPath.includes(`${path.sep}.local${path.sep}bin${path.sep}`);
             if (isBinaryInstall) { return pythonExe; }
 
-            // Legacy venv (pip install jaclang): python sits next to jac in bin/.
+            // Legacy pip venv: python sits next to jac in bin/.
             return path.join(path.dirname(this.jacPath), pythonExe);
         }
         return pythonExe;

--- a/src/environment/manager.ts
+++ b/src/environment/manager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import * as path from 'path';
 import { discoverJacEnvironments, validateJacExecutable, JacEnvironment } from '../utils/envDetection';
 import { getJacVersion, compareVersions } from '../utils/envVersion';
@@ -92,12 +93,13 @@ export class EnvManager {
     getPythonPath(): string {
         const pythonExe = process.platform === 'win32' ? 'python.exe' : 'python';
         if (this.jacPath) {
-            // ~/.local/bin/jac is the binary installer — Python is embedded, no sibling in bin/.
-            const isBinaryInstall = this.jacPath.includes(`${path.sep}.local${path.sep}bin${path.sep}`);
-            if (isBinaryInstall) { return pythonExe; }
+            // Legacy pip venv ships a sibling python in bin/; use it when present.
+            const sibling = path.join(path.dirname(this.jacPath), pythonExe);
+            if (fs.existsSync(sibling)) { return sibling; }
 
-            // Legacy pip venv: python sits next to jac in bin/.
-            return path.join(path.dirname(this.jacPath), pythonExe);
+            // Single binary (any install location - .local, brew, /usr/local) has
+            // Python embedded, so there is no sibling. Fall back to bare python.
+            return pythonExe;
         }
         return pythonExe;
     }

--- a/src/utils/envDetection.ts
+++ b/src/utils/envDetection.ts
@@ -64,18 +64,12 @@ async function walkForVenvs(baseDir: string, depth: number): Promise<string[]> {
 
 // ── Environment Locators ─────────────────────────────────────────────────────
 
-// Locator 0: Checks well-known binary install locations directly (no PATH dependency).
+// Locator 0: Checks ~/.local/bin/jac directly (no PATH dependency).
 // Catches the case where ~/.local/bin isn't on PATH yet (common right after install).
 async function findDefaultBinary(): Promise<string[]> {
-    const homeDir = os.homedir();
-    const isWin = process.platform === 'win32';
-    const jacExe = isWin ? 'jac.exe' : 'jac';
-    const candidates = isWin ? [] : [
-        path.join(homeDir, '.local', 'bin', jacExe),   // curl installer default
-        '/usr/local/bin/jac',                            // manual / system-wide installs
-    ];
-    const results = await Promise.all(candidates.map(async p => (await fileExists(p)) ? p : null));
-    return results.filter((p): p is string => p !== null);
+    if (process.platform === 'win32') return [];
+    const jacPath = path.join(os.homedir(), '.local', 'bin', 'jac'); // Mac/Linux only — Windows returns early above
+    return (await fileExists(jacPath)) ? [jacPath] : [];
 }
 
 // Locator 1: Scans $PATH for jac

--- a/src/utils/envDetection.ts
+++ b/src/utils/envDetection.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import type { Dirent } from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -63,6 +64,20 @@ async function walkForVenvs(baseDir: string, depth: number): Promise<string[]> {
 
 // ── Environment Locators ─────────────────────────────────────────────────────
 
+// Locator 0: Checks well-known binary install locations directly (no PATH dependency).
+// Catches the case where ~/.local/bin isn't on PATH yet (common right after install).
+async function findDefaultBinary(): Promise<string[]> {
+    const homeDir = os.homedir();
+    const isWin = process.platform === 'win32';
+    const jacExe = isWin ? 'jac.exe' : 'jac';
+    const candidates = isWin ? [] : [
+        path.join(homeDir, '.local', 'bin', jacExe),   // curl installer default
+        '/usr/local/bin/jac',                            // manual / system-wide installs
+    ];
+    const results = await Promise.all(candidates.map(async p => (await fileExists(p)) ? p : null));
+    return results.filter((p): p is string => p !== null);
+}
+
 // Locator 1: Scans $PATH for jac
 async function findInPath(): Promise<string[]> {
     const isWin = process.platform === 'win32';
@@ -119,9 +134,19 @@ async function findInCondaEnvs(): Promise<string[]> {
     return jacResults.filter((result): result is string => result !== null);
 }
 
-// Locator 3: Finds venvs in workspace
+// Locator 3: Finds jac in workspace — checks .jac/venv first (new binary model),
+// then falls back to walking for old-style .venv folders (backward compat).
 async function findInWorkspace(workspaceRoot: string): Promise<string[]> {
-    return walkForVenvs(workspaceRoot, VENV_WALK_DEPTH);
+    // .jac/venv is where `jac install` puts plugins in the new binary model.
+    // It contains a real jac binary that the extension can use directly.
+    const jacVenv = path.join(workspaceRoot, '.jac', 'venv');
+    const jacInPluginVenv = await getJacInEnv(jacVenv);
+    const pluginResult = jacInPluginVenv ? [jacInPluginVenv] : [];
+
+    // Also walk for old-style .venv folders (pip install jaclang, backward compat)
+    const venvResults = await walkForVenvs(workspaceRoot, VENV_WALK_DEPTH);
+
+    return [...pluginResult, ...venvResults];
 }
 
 // Locator 4: Finds venvs in home directory stores
@@ -149,7 +174,8 @@ export interface JacEnvironment {
 
 // Discovers all Jac environments on-demand (~10-15ms)
 export async function discoverJacEnvironments(workspaceRoots: string[]): Promise<JacEnvironment[]> {
-    const [pathEnvs, condaEnvs, homeEnvs, ...workspaceResults] = await Promise.all([
+    const [defaultBinaries, pathEnvs, condaEnvs, homeEnvs, ...workspaceResults] = await Promise.all([
+        findDefaultBinary(),
         findInPath(),
         findInCondaEnvs(),
         findInHome(),
@@ -167,8 +193,9 @@ export async function discoverJacEnvironments(workspaceRoots: string[]): Promise
         }
     };
 
-    // Priority: workspace > global > conda > home venvs
+    // Priority: workspace (.jac/venv + .venv) > default binary > PATH > conda > home venvs
     workspaceEnvs.forEach(envPath => add(envPath, 'workspace'));
+    defaultBinaries.forEach(envPath => add(envPath, 'global'));
     pathEnvs.forEach(envPath => add(envPath, 'global'));
     condaEnvs.forEach(envPath => add(envPath, 'conda'));
     homeEnvs.forEach(envPath => add(envPath, 'venv'));

--- a/src/utils/envDetection.ts
+++ b/src/utils/envDetection.ts
@@ -128,19 +128,9 @@ async function findInCondaEnvs(): Promise<string[]> {
     return jacResults.filter((result): result is string => result !== null);
 }
 
-// Locator 3: Finds jac in workspace — checks .jac/venv first (new binary model),
-// then falls back to walking for old-style .venv folders (backward compat).
+// Locator 3: Finds venvs in workspace
 async function findInWorkspace(workspaceRoot: string): Promise<string[]> {
-    // .jac/venv is where `jac install` puts plugins in the new binary model.
-    // It contains a real jac binary that the extension can use directly.
-    const jacVenv = path.join(workspaceRoot, '.jac', 'venv');
-    const jacInPluginVenv = await getJacInEnv(jacVenv);
-    const pluginResult = jacInPluginVenv ? [jacInPluginVenv] : [];
-
-    // Also walk for old-style .venv folders (pip install jaclang, backward compat)
-    const venvResults = await walkForVenvs(workspaceRoot, VENV_WALK_DEPTH);
-
-    return [...pluginResult, ...venvResults];
+    return walkForVenvs(workspaceRoot, VENV_WALK_DEPTH);
 }
 
 // Locator 4: Finds venvs in home directory stores
@@ -187,7 +177,7 @@ export async function discoverJacEnvironments(workspaceRoots: string[]): Promise
         }
     };
 
-    // Priority: workspace (.jac/venv + .venv) > default binary > PATH > conda > home venvs
+    // Priority: workspace > default binary (~/.local/bin) > PATH > conda > home venvs
     workspaceEnvs.forEach(envPath => add(envPath, 'workspace'));
     defaultBinaries.forEach(envPath => add(envPath, 'global'));
     pathEnvs.forEach(envPath => add(envPath, 'global'));

--- a/src/utils/envDetection.ts
+++ b/src/utils/envDetection.ts
@@ -64,11 +64,24 @@ async function walkForVenvs(baseDir: string, depth: number): Promise<string[]> {
 
 // ── Environment Locators ─────────────────────────────────────────────────────
 
-// Locator 0: Checks ~/.local/bin/jac directly — catches fresh installs where ~/.local/bin isn't on PATH yet.
+// Locator 0: Checks well-known single-binary install locations directly - catches
+// fresh installs before the install dir is on PATH. Cross-platform.
 async function findDefaultBinary(): Promise<string[]> {
-    if (process.platform === 'win32') return [];
-    const jacPath = path.join(os.homedir(), '.local', 'bin', 'jac');
-    return (await fileExists(jacPath)) ? [jacPath] : [];
+    const home = os.homedir();
+    const candidates = process.platform === 'win32'
+        ? [
+            path.join(process.env.LOCALAPPDATA ?? path.join(home, 'AppData', 'Local'), 'Programs', 'jac', 'jac.exe'),
+            path.join(process.env.LOCALAPPDATA ?? path.join(home, 'AppData', 'Local'), 'jac', 'bin', 'jac.exe'),
+        ]
+        : [
+            path.join(home, '.local', 'bin', 'jac'),
+            '/opt/homebrew/bin/jac', // macOS arm brew
+            '/usr/local/bin/jac',
+        ];
+    const results = await Promise.all(
+        candidates.map(async c => (await fileExists(c)) ? c : null)
+    );
+    return results.filter((c): c is string => c !== null);
 }
 
 // Locator 1: Scans $PATH for jac

--- a/src/utils/envDetection.ts
+++ b/src/utils/envDetection.ts
@@ -64,11 +64,10 @@ async function walkForVenvs(baseDir: string, depth: number): Promise<string[]> {
 
 // ── Environment Locators ─────────────────────────────────────────────────────
 
-// Locator 0: Checks ~/.local/bin/jac directly (no PATH dependency).
-// Catches the case where ~/.local/bin isn't on PATH yet (common right after install).
+// Locator 0: Checks ~/.local/bin/jac directly — catches fresh installs where ~/.local/bin isn't on PATH yet.
 async function findDefaultBinary(): Promise<string[]> {
     if (process.platform === 'win32') return [];
-    const jacPath = path.join(os.homedir(), '.local', 'bin', 'jac'); // Mac/Linux only — Windows returns early above
+    const jacPath = path.join(os.homedir(), '.local', 'bin', 'jac');
     return (await fileExists(jacPath)) ? [jacPath] : [];
 }
 

--- a/src/utils/envVersion.ts
+++ b/src/utils/envVersion.ts
@@ -1,33 +1,53 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import * as os from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
-// Finds jaclang version by scanning site-packages for a jaclang-*.dist-info folder (~1ms, no subprocess).
-// Returns undefined if version cannot be determined.
-export async function getJacVersion(jacPath: string): Promise<string | undefined> {
-    try {
-        const envRoot = path.dirname(path.dirname(jacPath));
-        const libDir  = path.join(envRoot, 'lib');
+const execFileAsync = promisify(execFile);
 
-        let libEntries: string[];
-        try { libEntries = await fs.readdir(libDir); }
-        catch { return undefined; }
+// Fast path: scan ~/.cache/jac/rt/*/site/jaclang-*.dist-info (~0.002s, no subprocess).
+// If multiple cache dirs found (e.g. dev build + release), skip and fall back to subprocess.
+async function getJacVersionFromCache(): Promise<string | undefined> {
+    const cacheBase = process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache');
+    const rtDir = path.join(cacheBase, 'jac', 'rt');
 
-        for (const libEntry of libEntries.filter(entry => entry.startsWith('python'))) {
-            for (const pkgDir of ['site-packages', 'dist-packages']) {
-                try {
-                    const sitePackages = path.join(libDir, libEntry, pkgDir);
-                    const siteEntries  = await fs.readdir(sitePackages);
-                    const distInfoDir  = siteEntries.find(
-                        entry => entry.startsWith('jaclang-') && entry.endsWith('.dist-info')
-                    );
-                    if (distInfoDir) {
-                        return distInfoDir.slice('jaclang-'.length, -'.dist-info'.length);
-                    }
-                } catch { continue; }
-            }
+    let hashDirs: string[];
+    try { hashDirs = await fs.readdir(rtDir); }
+    catch { return undefined; }
+
+    const versions: string[] = [];
+
+    for (const hashDir of hashDirs) {
+        const siteDir = path.join(rtDir, hashDir, 'site');
+        let entries: string[];
+        try { entries = await fs.readdir(siteDir); }
+        catch { continue; }
+
+        const distInfo = entries.find(e => e.startsWith('jaclang-') && e.endsWith('.dist-info'));
+        if (distInfo) {
+            versions.push(distInfo.slice('jaclang-'.length, -'.dist-info'.length));
         }
-        return undefined;
+    }
+
+    // Multiple distinct versions in cache = ambiguous (dev build + release coexist).
+    // Fall back to subprocess so we don't show wrong version.
+    const unique = [...new Set(versions)];
+    return unique.length === 1 ? unique[0] : undefined;
+}
+
+// Slow fallback: run jac --version (~1.8s). Only hits when cache doesn't exist yet
+// (first-ever run before jac has been invoked). Runs silently in background.
+async function getJacVersionFromBinary(jacPath: string): Promise<string | undefined> {
+    try {
+        const { stdout } = await execFileAsync(jacPath, ['--version'], { timeout: 5000 });
+        return stdout.match(/Version:\s+([\d.]+)/)?.[1];
     } catch { return undefined; }
+}
+
+// Cache first (~0.002s). Subprocess fallback only if cache is missing.
+export async function getJacVersion(jacPath: string): Promise<string | undefined> {
+    return (await getJacVersionFromCache()) ?? (await getJacVersionFromBinary(jacPath));
 }
 
 // Compares two semver strings. Returns positive if a > b, negative if a < b, 0 if equal.

--- a/src/utils/envVersion.ts
+++ b/src/utils/envVersion.ts
@@ -6,8 +6,7 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
-// Fast path: scan ~/.cache/jac/rt/*/site/jaclang-*.dist-info (~0.002s, no subprocess).
-// If multiple cache dirs found (e.g. dev build + release), skip and fall back to subprocess.
+// Fast path: read version from ~/.cache/jac/rt/*/site/jaclang-*.dist-info (~0.002s).
 async function getJacVersionFromCache(): Promise<string | undefined> {
     const cacheBase = process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache');
     const rtDir = path.join(cacheBase, 'jac', 'rt');
@@ -30,14 +29,12 @@ async function getJacVersionFromCache(): Promise<string | undefined> {
         }
     }
 
-    // Multiple distinct versions in cache = ambiguous (dev build + release coexist).
-    // Fall back to subprocess so we don't show wrong version.
+    // Ambiguous if multiple distinct versions (e.g. dev + release) — fall back to subprocess.
     const unique = [...new Set(versions)];
     return unique.length === 1 ? unique[0] : undefined;
 }
 
-// Slow fallback: run jac --version (~1.8s). Only hits when cache doesn't exist yet
-// (first-ever run before jac has been invoked). Runs silently in background.
+// Slow fallback (~1.8s): only runs if cache is missing (first-ever launch).
 async function getJacVersionFromBinary(jacPath: string): Promise<string | undefined> {
     try {
         const { stdout } = await execFileAsync(jacPath, ['--version'], { timeout: 5000 });
@@ -45,7 +42,7 @@ async function getJacVersionFromBinary(jacPath: string): Promise<string | undefi
     } catch { return undefined; }
 }
 
-// Cache first (~0.002s). Subprocess fallback only if cache is missing.
+// Cache first, subprocess fallback if cache is missing.
 export async function getJacVersion(jacPath: string): Promise<string | undefined> {
     return (await getJacVersionFromCache()) ?? (await getJacVersionFromBinary(jacPath));
 }


### PR DESCRIPTION
## What changed and why

Jac recently switched from `pip install jaclang` to a self-contained binary installer:

```bash
curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
```

This installs a single `jac` binary to `~/.local/bin/jac` with Python embedded inside — no virtual environment needed. The VS Code extension wasn't built for this model, so it failed to detect jac and showed **"No Env"** even when jac was properly installed.

---

## What was broken before

| Situation | Before | After |
|---|---|---|
| jac installed via binary installer | ❌ "No Env" — extension couldn't find it | ✅ Auto-detected at `~/.local/bin/jac` |
| Version shown in status bar | ❌ Ran `jac --version` subprocess (~1.8s delay) | ✅ Reads from `~/.cache/jac/rt/` folder name (~0.002s) |
| Workspace with `jac install` plugins | ❌ `.jac/venv/` not checked | ✅ `.jac/venv/` checked first before walking `.venv/` |
| Python path for binary install | ❌ Looked for `~/.local/bin/python` (doesn't exist) | ✅ Falls back to bare `python` (embedded inside jac) |
| QuickPick label | ❌ Showed `Jac 0.30.2 (.local)` (confusing) | ✅ Shows `Jac 0.30.2` — path already visible in description |

---

## Files changed

**`src/utils/envVersion.ts`**
- Added fast version detection: scans `~/.cache/jac/rt/*/site/jaclang-*.dist-info` folder name instead of running a subprocess
- `jac --version` subprocess is now only a fallback (first launch before jac has ever run)

**`src/utils/envDetection.ts`**
- Added `findDefaultBinary()`: checks `~/.local/bin/jac` and `/usr/local/bin/jac` directly, without relying on PATH (common problem right after install)
- Updated `findInWorkspace()`: checks `.jac/venv/` first (new plugin venv from `jac install`), then old-style `.venv/` folders
- Priority order: workspace > default binary > PATH > conda > home venvs

**`src/environment/manager.ts`**
- `getPythonPath()`: binary install paths return bare `python` instead of looking for a non-existent sibling binary
- `buildEnvItem()`: global binary installs no longer show a confusing `(.local)` name in the QuickPick label
