### PR TITLE
fix: detect jaclang version and interpreter for the single binary

### DIFF
--- a/src/__tests__/env_test.test.ts
+++ b/src/__tests__/env_test.test.ts
@@ -415,12 +415,21 @@ describe('EnvManager', () => {
     });
 
     describe('getPythonPath()', () => {
-        test('returns python in the same directory as the configured jac executable', () => {
+        test('returns the sibling python when one exists on disk (venv/conda)', () => {
+            const existsSpy = jest.spyOn(require('fs'), 'existsSync').mockReturnValue(true);
             (envManager as any).jacPath = '/home/user/.venv/bin/jac';
             const expected = process.platform === 'win32'
                 ? '/home/user/.venv/bin/python.exe'
                 : '/home/user/.venv/bin/python';
             expect(envManager.getPythonPath()).toBe(expected);
+            existsSpy.mockRestore();
+        });
+
+        test('returns the jac executable itself when no sibling python exists (single binary)', () => {
+            const existsSpy = jest.spyOn(require('fs'), 'existsSync').mockReturnValue(false);
+            (envManager as any).jacPath = '/home/user/.local/bin/jac';
+            expect(envManager.getPythonPath()).toBe('/home/user/.local/bin/jac');
+            existsSpy.mockRestore();
         });
 
         test('falls back to the platform default when no path is configured', () => {

--- a/src/environment/manager.ts
+++ b/src/environment/manager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import * as path from 'path';
 import { discoverJacEnvironments, validateJacExecutable, JacEnvironment } from '../utils/envDetection';
 import { getJacVersion, compareVersions } from '../utils/envVersion';
@@ -93,7 +94,11 @@ export class EnvManager {
         if (this.jacPath) {
             const jacDir = path.dirname(this.jacPath);
             const pythonExe = process.platform === 'win32' ? 'python.exe' : 'python';
-            return path.join(jacDir, pythonExe);
+            const sibling = path.join(jacDir, pythonExe);
+            // Genuine venv/conda installs ship a sibling python; use it when present.
+            if (fs.existsSync(sibling)) { return sibling; }
+            // Single self-contained binary has no sibling python - the binary IS the interpreter host.
+            return this.jacPath;
         }
         return process.platform === 'win32' ? 'python.exe' : 'python';
     }

--- a/src/utils/envDetection.ts
+++ b/src/utils/envDetection.ts
@@ -140,6 +140,33 @@ async function findInHome(): Promise<string[]> {
     return results.flat();
 }
 
+// Locator 5: Finds the single self-contained native binary in well-known install locations
+// (PATH-independent, so it is found even when not on PATH).
+async function findSingleBinaryInstalls(): Promise<string[]> {
+    const isWin = process.platform === 'win32';
+    const candidates: string[] = [];
+
+    if (isWin) {
+        const localAppData = process.env.LOCALAPPDATA || '';
+        if (localAppData) {
+            candidates.push(path.join(localAppData, 'Programs', 'jac', 'jac.exe'));
+            candidates.push(path.join(localAppData, 'jac', 'bin', 'jac.exe'));
+        }
+    } else {
+        const homeDir = process.env.HOME || process.env.USERPROFILE || '';
+        if (homeDir) {
+            candidates.push(path.join(homeDir, '.local', 'bin', 'jac'));
+        }
+        candidates.push('/opt/homebrew/bin/jac'); // macOS arm brew
+        candidates.push('/usr/local/bin/jac');
+    }
+
+    const results = await Promise.all(
+        candidates.map(async candidate => (await fileExists(candidate)) ? candidate : null)
+    );
+    return results.filter((candidate): candidate is string => candidate !== null);
+}
+
 // ── Main Discovery ───────────────────────────────────────────────────────────
 
 export interface JacEnvironment {
@@ -149,8 +176,9 @@ export interface JacEnvironment {
 
 // Discovers all Jac environments on-demand (~10-15ms)
 export async function discoverJacEnvironments(workspaceRoots: string[]): Promise<JacEnvironment[]> {
-    const [pathEnvs, condaEnvs, homeEnvs, ...workspaceResults] = await Promise.all([
+    const [pathEnvs, singleBinaryEnvs, condaEnvs, homeEnvs, ...workspaceResults] = await Promise.all([
         findInPath(),
+        findSingleBinaryInstalls(),
         findInCondaEnvs(),
         findInHome(),
         ...workspaceRoots.map(findInWorkspace)
@@ -167,9 +195,10 @@ export async function discoverJacEnvironments(workspaceRoots: string[]): Promise
         }
     };
 
-    // Priority: workspace > global > conda > home venvs
+    // Priority: workspace > global (PATH + single-binary installs) > conda > home venvs
     workspaceEnvs.forEach(envPath => add(envPath, 'workspace'));
     pathEnvs.forEach(envPath => add(envPath, 'global'));
+    singleBinaryEnvs.forEach(envPath => add(envPath, 'global'));
     condaEnvs.forEach(envPath => add(envPath, 'conda'));
     homeEnvs.forEach(envPath => add(envPath, 'venv'));
 

--- a/src/utils/envVersion.ts
+++ b/src/utils/envVersion.ts
@@ -1,9 +1,35 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { execFile } from 'child_process';
 
-// Finds jaclang version by scanning site-packages for a jaclang-*.dist-info folder (~1ms, no subprocess).
-// Returns undefined if version cannot be determined.
+// Matches the version on `jac --version` output: e.g. "Version:  0.30.2" (allows pre-release/build suffixes).
+const VERSION_RE = /Version:\s*([0-9]+\.[0-9]+\.[0-9]+(?:[.\-+][0-9A-Za-z.\-]+)?)/;
+
+// Resolves the Jac version. The single native binary is the source of truth, so we ask it directly via
+// `jac --version`. Falls back to scanning site-packages for a jaclang-*.dist-info folder (offline/pip installs).
+// Returns undefined if version cannot be determined. Never throws.
 export async function getJacVersion(jacPath: string): Promise<string | undefined> {
+    const fromBinary = await getVersionFromBinary(jacPath);
+    if (fromBinary) { return fromBinary; }
+    return getVersionFromDistInfo(jacPath);
+}
+
+// Primary: spawn the jac executable with --version and parse stdout.
+async function getVersionFromBinary(jacPath: string): Promise<string | undefined> {
+    return new Promise(resolve => {
+        try {
+            // Absolute path runs directly; a bare name is resolved via PATH.
+            execFile(jacPath, ['--version'], { timeout: 5000 }, (err, stdout, stderr) => {
+                if (err) { return resolve(undefined); }
+                const match = VERSION_RE.exec(`${stdout}\n${stderr}`);
+                resolve(match ? match[1] : undefined);
+            });
+        } catch { resolve(undefined); }
+    });
+}
+
+// Fallback: scan site-packages for a jaclang-*.dist-info folder (~1ms, no subprocess).
+async function getVersionFromDistInfo(jacPath: string): Promise<string | undefined> {
     try {
         const envRoot = path.dirname(path.dirname(jacPath));
         const libDir  = path.join(envRoot, 'lib');


### PR DESCRIPTION
## Problem

`jaclang` now ships as one self-contained native binary (Zig launcher + bundled CPython), not a pip-installed package in a venv. The extension's env model still assumed the old layout, which surfaced as a wrong version in the status bar and a broken interpreter path.

Concretely, with the single binary at `~/.local/bin/jac` (really 0.30.2), the status bar showed an unrelated **0.6.1** because `getJacVersion()` scanned `lib/python*/site-packages` next to the binary and matched a stale pip leftover (`jaclang-0.6.1.dist-info`). The single binary has no such sibling dist-info.

## Fix

- **Version (`envVersion.ts`)** - ask the binary directly via `jac --version` and parse the `Version: X.Y.Z` line; fall back to the existing dist-info scan for genuine pip installs. Source of truth is now the binary, so resolution is location-independent across Linux/macOS/Windows. Never throws.
- **Interpreter path (`manager.ts`)** - `getPythonPath()` returned a sibling `python` that does not exist next to the single binary. It now returns the sibling only when it exists on disk (venv/conda) and otherwise the `jac` binary itself (it is the interpreter host).
- **Discovery (`envDetection.ts`)** - also locate the single binary at its well-known install locations independent of PATH: `~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin` (Linux/macOS) and `%LOCALAPPDATA%\Programs\jac`, `%LOCALAPPDATA%\jac\bin` (Windows).

The LSP launch model (`jac lsp`) was already single-binary correct and is unchanged.

## Validation

- `npx tsc --noEmit` clean; `npm run test:unit` -> 272 passed.
- Live-checked on Ubuntu 22.04: `getJacVersion('~/.local/bin/jac')` now resolves **0.30.2** (was 0.6.1). The dev-mode banner in `jac --version` output does not interfere with parsing.