### PR TITLE
fix: open QuickPick instantly and avoid subprocess for binary version

### DIFF
--- a/src/environment/manager.ts
+++ b/src/environment/manager.ts
@@ -127,10 +127,9 @@ export class EnvManager {
             type EnvItem = vscode.QuickPickItem & { envPath?: string };
 
             const quickPick = vscode.window.createQuickPick<EnvItem>();
-            const currentVersion = this.jacPath ? await getJacVersion(this.jacPath) : undefined;
             const currentEnvName = this.jacPath ? this.getEnvName(this.jacPath) : undefined;
-            const currentLabel = currentVersion && currentEnvName
-                ? `Jac Environment · currently: ${currentVersion} (${currentEnvName})`
+            const currentLabel = this.jacVersion && currentEnvName
+                ? `Jac Environment · currently: ${this.jacVersion} (${currentEnvName})`
                 : 'Select Jac Environment';
             quickPick.title = currentLabel;
             quickPick.placeholder = 'Searching for Jac environments...';

--- a/src/utils/envDetection.ts
+++ b/src/utils/envDetection.ts
@@ -141,7 +141,7 @@ async function findInCondaEnvs(): Promise<string[]> {
 }
 
 // Locator 3: Finds venvs + zig-out dev builds in workspace.
-// Checks zig-out/bin/jac at root and one level deep (covers both jaseci/ and jaseci/jac/ as workspace).
+// Scans zig-out/bin/jac up to two levels deep (workspace may be jaseci/jac/, jaseci/, or a parent).
 async function findInWorkspace(workspaceRoot: string): Promise<string[]> {
     const venvs = await walkForVenvs(workspaceRoot, VENV_WALK_DEPTH);
 
@@ -153,15 +153,20 @@ async function findInWorkspace(workspaceRoot: string): Promise<string[]> {
         if (await fileExists(candidate)) zigOutPaths.push(candidate);
     };
 
-    await checkZigOut(workspaceRoot);
-    let entries: Dirent[];
-    try { entries = await fs.readdir(workspaceRoot, { withFileTypes: true }); }
-    catch { entries = []; }
-    await Promise.all(
-        entries
-            .filter(e => e.isDirectory() && !e.name.startsWith('.'))
-            .map(e => checkZigOut(path.join(workspaceRoot, e.name)))
-    );
+    const scanDir = async (dir: string, depth: number) => {
+        await checkZigOut(dir);
+        if (depth === 0) return;
+        let entries: Dirent[];
+        try { entries = await fs.readdir(dir, { withFileTypes: true }); }
+        catch { return; }
+        await Promise.all(
+            entries
+                .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+                .map(e => scanDir(path.join(dir, e.name), depth - 1))
+        );
+    };
+
+    await scanDir(workspaceRoot, 2);
 
     return [...venvs, ...zigOutPaths];
 }

--- a/src/utils/envDetection.ts
+++ b/src/utils/envDetection.ts
@@ -36,7 +36,7 @@ async function getJacInEnv(envPath: string): Promise<string | null> {
     return (await fileExists(jacPath)) ? jacPath : null;
 }
 
-// Walks directories looking for venvs (identified by pyvenv.cfg) with jac installed
+// Walks dirs for venvs (pyvenv.cfg). Skips .jac/ — those are project plugin venvs.
 async function walkForVenvs(baseDir: string, depth: number): Promise<string[]> {
     if (depth === 0) return [];
 
@@ -49,7 +49,7 @@ async function walkForVenvs(baseDir: string, depth: number): Promise<string[]> {
 
     const results = await Promise.all(
         entries
-            .filter(dirEntry => dirEntry.isDirectory())
+            .filter(dirEntry => dirEntry.isDirectory() && dirEntry.name !== '.jac')
             .map(async (dirEntry): Promise<string[]> => {
                 const fullPath = path.join(baseDir, dirEntry.name);
                 if (await isVenv(fullPath)) {
@@ -140,9 +140,30 @@ async function findInCondaEnvs(): Promise<string[]> {
     return jacResults.filter((result): result is string => result !== null);
 }
 
-// Locator 3: Finds venvs in workspace
+// Locator 3: Finds venvs + zig-out dev builds in workspace.
+// Checks zig-out/bin/jac at root and one level deep (covers both jaseci/ and jaseci/jac/ as workspace).
 async function findInWorkspace(workspaceRoot: string): Promise<string[]> {
-    return walkForVenvs(workspaceRoot, VENV_WALK_DEPTH);
+    const venvs = await walkForVenvs(workspaceRoot, VENV_WALK_DEPTH);
+
+    const jacExe = process.platform === 'win32' ? 'jac.exe' : 'jac';
+    const zigOutPaths: string[] = [];
+
+    const checkZigOut = async (dir: string) => {
+        const candidate = path.join(dir, 'zig-out', 'bin', jacExe);
+        if (await fileExists(candidate)) zigOutPaths.push(candidate);
+    };
+
+    await checkZigOut(workspaceRoot);
+    let entries: Dirent[];
+    try { entries = await fs.readdir(workspaceRoot, { withFileTypes: true }); }
+    catch { entries = []; }
+    await Promise.all(
+        entries
+            .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+            .map(e => checkZigOut(path.join(workspaceRoot, e.name)))
+    );
+
+    return [...venvs, ...zigOutPaths];
 }
 
 // Locator 4: Finds venvs in home directory stores
@@ -196,7 +217,18 @@ export async function discoverJacEnvironments(workspaceRoots: string[]): Promise
     condaEnvs.forEach(envPath => add(envPath, 'conda'));
     homeEnvs.forEach(envPath => add(envPath, 'venv'));
 
-    return envs;
+    // Dedup by realpath: --dev install symlinks ~/.local/bin/jac → zig-out/bin/jac.
+    const seenReal = new Set<string>();
+    const deduped: JacEnvironment[] = [];
+    for (const env of envs) {
+        let real: string;
+        try { real = await fs.realpath(env.path); } catch { real = env.path; }
+        if (!seenReal.has(real)) {
+            seenReal.add(real);
+            deduped.push(env);
+        }
+    }
+    return deduped;
 }
 
 // ── Validation ───────────────────────────────────────────────────────────────

--- a/src/utils/envVersion.ts
+++ b/src/utils/envVersion.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { createHash } from 'crypto';
 
 const execFileAsync = promisify(execFile);
 
@@ -46,23 +47,61 @@ async function getJacVersionFromDistInfo(jacPath: string): Promise<string | unde
     } catch { return undefined; }
 }
 
-// Middle path: scan ~/.cache/jac/rt/*/site/jaclang-*.dist-info — no subprocess, works for binary installs.
-async function getJacVersionFromCache(): Promise<string | undefined> {
+// Middle path: scan ~/.cache/jac/rt/*/site/jaclang-*.dist-info, keyed on jacPath.
+// New format (≥0.30.3): <hash16>-<pathhash16> — per binary. Old format (≤0.30.2): <hash16> — shared.
+// Old format used only when no new-format dirs exist (prevents cross-version pollution).
+async function getJacVersionFromCache(jacPath: string): Promise<string | undefined> {
     const cacheBase = process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache');
     const rtDir = path.join(cacheBase, 'jac', 'rt');
     let hashDirs: string[];
     try { hashDirs = await fs.readdir(rtDir); }
     catch { return undefined; }
-    const versions: string[] = [];
-    for (const hashDir of hashDirs) {
-        let entries: string[];
-        try { entries = await fs.readdir(path.join(rtDir, hashDir, 'site')); }
-        catch { continue; }
-        const distInfo = entries.find(e => e.startsWith('jaclang-') && e.endsWith('.dist-info'));
-        if (distInfo) versions.push(distInfo.slice('jaclang-'.length, -'.dist-info'.length));
+    if (hashDirs.length === 0) return undefined;
+
+    const RT_KEY_LEN = 33;
+    const HEX16 = /^[0-9a-f]{16}$/;
+
+    // Runtime hashes realpath(exe); try resolved first, fall back to raw (macOS symlink behaviour).
+    let resolvedPath: string;
+    try { resolvedPath = await fs.realpath(jacPath); } catch { resolvedPath = jacPath; }
+
+    const pathHashFor = (p: string) => createHash('sha256').update(p).digest('hex').slice(0, 16);
+
+    // New format: per-binary
+    const newFormatDirs = hashDirs.filter(d => d.length === RT_KEY_LEN && d[16] === '-');
+    let matchingDirs = newFormatDirs.filter(d => d.slice(17) === pathHashFor(resolvedPath));
+    if (matchingDirs.length === 0 && resolvedPath !== jacPath) {
+        matchingDirs = newFormatDirs.filter(d => d.slice(17) === pathHashFor(jacPath));
     }
-    const unique = [...new Set(versions)];
-    return unique.length === 1 ? unique[0] : undefined;
+
+    if (matchingDirs.length > 0) {
+        const versions: string[] = [];
+        for (const dir of matchingDirs) {
+            let entries: string[];
+            try { entries = await fs.readdir(path.join(rtDir, dir, 'site')); } catch { continue; }
+            const di = entries.find(e => e.startsWith('jaclang-') && e.endsWith('.dist-info'));
+            if (di) versions.push(di.slice('jaclang-'.length, -'.dist-info'.length));
+        }
+        const unique = [...new Set(versions)];
+        if (unique.length === 1) return unique[0];
+        return undefined;
+    }
+
+    // Old format: only when no new-format dirs exist (avoids returning stale version after GC).
+    const oldFormatDirs = hashDirs.filter(d => d.length === 16 && HEX16.test(d));
+    if (newFormatDirs.length === 0 && oldFormatDirs.length > 0) {
+        const versions: string[] = [];
+        for (const dir of oldFormatDirs) {
+            let entries: string[];
+            try { entries = await fs.readdir(path.join(rtDir, dir, 'site')); } catch { continue; }
+            const di = entries.find(e => e.startsWith('jaclang-') && e.endsWith('.dist-info'));
+            if (di) versions.push(di.slice('jaclang-'.length, -'.dist-info'.length));
+        }
+        const unique = [...new Set(versions)];
+        if (unique.length === 1) return unique[0];
+    }
+
+    return undefined;
 }
 
 // Last resort: ask the specific binary directly (~1.8s, may be slow on cold cache).
@@ -75,7 +114,7 @@ async function getJacVersionFromBinary(jacPath: string): Promise<string | undefi
 
 // dist-info (venvs) → cache scan (binary install, no subprocess) → subprocess (last resort).
 export async function getJacVersion(jacPath: string): Promise<string | undefined> {
-    return (await getJacVersionFromDistInfo(jacPath)) ?? (await getJacVersionFromCache()) ?? (await getJacVersionFromBinary(jacPath));
+    return (await getJacVersionFromDistInfo(jacPath)) ?? (await getJacVersionFromCache(jacPath)) ?? (await getJacVersionFromBinary(jacPath));
 }
 
 // Compares two semver strings. Returns positive if a > b, negative if a < b, 0 if equal.

--- a/src/utils/envVersion.ts
+++ b/src/utils/envVersion.ts
@@ -10,6 +10,53 @@ const execFileAsync = promisify(execFile);
 // Matches the version on `jac --version` output, e.g. "Version:  0.30.2".
 const VERSION_RE = /Version:\s*([0-9]+\.[0-9]+\.[0-9]+(?:[.\-+][0-9A-Za-z.\-]+)?)/;
 
+// Cold `jac --version` extracts the full runtime payload and can take 10s+.
+const VERSION_SUBPROCESS_TIMEOUT_MS = 30000;
+
+function jacCacheBase(): string {
+    return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache');
+}
+
+// ── Persistent version memo ──────────────────────────────────────────────────
+// jac's gcStale wipes other binaries' rt cache dirs, so with 2+ binaries the rt cache
+// can't hold every version. Memo keyed by hash16 (payload content hash) never goes stale.
+
+const memoFile = () => path.join(jacCacheBase(), 'jac-vscode', 'versions.json');
+let memoCache: Record<string, string> | undefined;
+
+async function memoLoad(): Promise<Record<string, string>> {
+    if (memoCache) return memoCache;
+    try { memoCache = JSON.parse(await fs.readFile(memoFile(), 'utf-8')); }
+    catch { memoCache = {}; }
+    return memoCache!;
+}
+
+async function memoStore(hash16: string, version: string): Promise<void> {
+    const memo = await memoLoad();
+    if (memo[hash16] === version) return;
+    memo[hash16] = version;
+    try {
+        await fs.mkdir(path.dirname(memoFile()), { recursive: true });
+        await fs.writeFile(memoFile(), JSON.stringify(memo, null, 2));
+    } catch { /* memo is best-effort */ }
+}
+
+// Reads the 80-byte trailer from a jac binary to get the hash16 (payload identity, ~0ms).
+// Trailer layout: JACBIN01 (8) | payload_len u64le (8) | sha256hex (64)
+async function getBinaryHash16(jacPath: string): Promise<string | undefined> {
+    try {
+        const { size } = await fs.stat(jacPath);
+        if (size < 80) return undefined;
+        const fh = await fs.open(jacPath, 'r');
+        try {
+            const buf = Buffer.alloc(80);
+            await fh.read(buf, 0, 80, size - 80);
+            if (buf.subarray(0, 8).toString('ascii') !== 'JACBIN01') return undefined;
+            return buf.subarray(16, 32).toString('ascii'); // first 16 chars of sha256hex
+        } finally { await fh.close(); }
+    } catch { return undefined; }
+}
+
 // Fast path: scan THIS env's own site-packages for a jaclang-*.dist-info (~1ms, no subprocess).
 // Keyed on the given jacPath so each env reports its own version. A single self-contained
 // binary has no sibling dist-info, so this returns undefined and the subprocess path is used.
@@ -47,12 +94,46 @@ async function getJacVersionFromDistInfo(jacPath: string): Promise<string | unde
     } catch { return undefined; }
 }
 
-// Middle path: scan ~/.cache/jac/rt/*/site/jaclang-*.dist-info, keyed on jacPath.
-// New format (≥0.30.3): <hash16>-<pathhash16> — per binary. Old format (≤0.30.2): <hash16> — shared.
-// Old format used only when no new-format dirs exist (prevents cross-version pollution).
-async function getJacVersionFromCache(jacPath: string): Promise<string | undefined> {
-    const cacheBase = process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache');
-    const rtDir = path.join(cacheBase, 'jac', 'rt');
+// Dev builds report the LIVE <repo>/jac.toml version at runtime, which can drift from
+// their build-time dist-info. Read jac.toml directly — instant and always correct.
+async function getJacVersionFromDevSource(jacPath: string): Promise<string | undefined> {
+    let resolved: string;
+    try { resolved = await fs.realpath(jacPath); } catch { resolved = jacPath; }
+
+    const binDir = path.dirname(resolved);                       // .../zig-out/bin
+    const zigOut = path.dirname(binDir);                         // .../zig-out
+    if (path.basename(binDir) !== 'bin' || path.basename(zigOut) !== 'zig-out') return undefined;
+
+    try {
+        const toml = await fs.readFile(path.join(path.dirname(zigOut), 'jac.toml'), 'utf-8');
+        return toml.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+    } catch { return undefined; }
+}
+
+// Reads the version from a jac runtime cache site/ dir.
+// Dev builds carry a jac_linked_source file pointing at the live source; its jac.toml wins.
+async function getVersionFromSiteDir(siteDir: string): Promise<string | undefined> {
+    try {
+        const linkedSource = (await fs.readFile(path.join(siteDir, 'jac_linked_source'), 'utf-8')).trim();
+        if (linkedSource) {
+            const toml = await fs.readFile(path.join(linkedSource, 'jac.toml'), 'utf-8');
+            const m = toml.match(/^version\s*=\s*"([^"]+)"/m);
+            if (m) return m[1];
+        }
+    } catch { /* not a dev build */ }
+
+    const entries = await fs.readdir(siteDir).catch(() => [] as string[]);
+    const di = entries.find(e => e.startsWith('jaclang-') && e.endsWith('.dist-info'));
+    return di ? di.slice('jaclang-'.length, -'.dist-info'.length) : undefined;
+}
+
+// Middle path: scan ~/.cache/jac/rt/*/site — no subprocess, ~2ms.
+//
+// Two cache dir formats:
+//   New (≥0.30.3): <hash16>-<pathhash16>  (33 chars) — per binary path
+//   Old (≤0.30.2): <hash16>               (16 chars) — per payload, shared
+async function getJacVersionFromCache(jacPath: string, hash16: string | undefined): Promise<string | undefined> {
+    const rtDir = path.join(jacCacheBase(), 'jac', 'rt');
     let hashDirs: string[];
     try { hashDirs = await fs.readdir(rtDir); }
     catch { return undefined; }
@@ -60,42 +141,38 @@ async function getJacVersionFromCache(jacPath: string): Promise<string | undefin
 
     const RT_KEY_LEN = 33;
     const HEX16 = /^[0-9a-f]{16}$/;
+    const newFormatDirs = hashDirs.filter(d => d.length === RT_KEY_LEN && d[16] === '-');
 
-    // Runtime hashes realpath(exe); try resolved first, fall back to raw (macOS symlink behaviour).
+    // 1. hash16 (payload identity) match — exact and path-independent
+    if (hash16) {
+        for (const dir of newFormatDirs.filter(d => d.startsWith(hash16 + '-'))) {
+            const ver = await getVersionFromSiteDir(path.join(rtDir, dir, 'site'));
+            if (ver) return ver;
+        }
+    }
+
+    // 2. pathhash match — covers binaries whose trailer we couldn't read
     let resolvedPath: string;
     try { resolvedPath = await fs.realpath(jacPath); } catch { resolvedPath = jacPath; }
 
     const pathHashFor = (p: string) => createHash('sha256').update(p).digest('hex').slice(0, 16);
 
-    // New format: per-binary
-    const newFormatDirs = hashDirs.filter(d => d.length === RT_KEY_LEN && d[16] === '-');
     let matchingDirs = newFormatDirs.filter(d => d.slice(17) === pathHashFor(resolvedPath));
     if (matchingDirs.length === 0 && resolvedPath !== jacPath) {
         matchingDirs = newFormatDirs.filter(d => d.slice(17) === pathHashFor(jacPath));
     }
-
-    if (matchingDirs.length > 0) {
-        const versions: string[] = [];
-        for (const dir of matchingDirs) {
-            let entries: string[];
-            try { entries = await fs.readdir(path.join(rtDir, dir, 'site')); } catch { continue; }
-            const di = entries.find(e => e.startsWith('jaclang-') && e.endsWith('.dist-info'));
-            if (di) versions.push(di.slice('jaclang-'.length, -'.dist-info'.length));
-        }
-        const unique = [...new Set(versions)];
-        if (unique.length === 1) return unique[0];
-        return undefined;
+    for (const dir of matchingDirs) {
+        const ver = await getVersionFromSiteDir(path.join(rtDir, dir, 'site'));
+        if (ver) return ver;
     }
 
-    // Old format: only when no new-format dirs exist (avoids returning stale version after GC).
+    // 3. Old format — only safe when no new-format dirs exist (avoids stale post-GC reads)
     const oldFormatDirs = hashDirs.filter(d => d.length === 16 && HEX16.test(d));
     if (newFormatDirs.length === 0 && oldFormatDirs.length > 0) {
         const versions: string[] = [];
         for (const dir of oldFormatDirs) {
-            let entries: string[];
-            try { entries = await fs.readdir(path.join(rtDir, dir, 'site')); } catch { continue; }
-            const di = entries.find(e => e.startsWith('jaclang-') && e.endsWith('.dist-info'));
-            if (di) versions.push(di.slice('jaclang-'.length, -'.dist-info'.length));
+            const ver = await getVersionFromSiteDir(path.join(rtDir, dir, 'site'));
+            if (ver) versions.push(ver);
         }
         const unique = [...new Set(versions)];
         if (unique.length === 1) return unique[0];
@@ -104,17 +181,31 @@ async function getJacVersionFromCache(jacPath: string): Promise<string | undefin
     return undefined;
 }
 
-// Last resort: ask the specific binary directly (~1.8s, may be slow on cold cache).
+// Last resort: ask the binary directly. Slow on cold cache; memoized so it runs once per binary.
 async function getJacVersionFromBinary(jacPath: string): Promise<string | undefined> {
     try {
-        const { stdout, stderr } = await execFileAsync(jacPath, ['--version'], { timeout: 5000 });
+        const { stdout, stderr } = await execFileAsync(jacPath, ['--version'], { timeout: VERSION_SUBPROCESS_TIMEOUT_MS });
         return VERSION_RE.exec(`${stdout}\n${stderr}`)?.[1];
     } catch { return undefined; }
 }
 
-// dist-info (venvs) → cache scan (binary install, no subprocess) → subprocess (last resort).
+// dist-info (venvs) → jac.toml (dev builds) → memo → rt cache → subprocess (result memoized).
 export async function getJacVersion(jacPath: string): Promise<string | undefined> {
-    return (await getJacVersionFromDistInfo(jacPath)) ?? (await getJacVersionFromCache(jacPath)) ?? (await getJacVersionFromBinary(jacPath));
+    const distInfo = await getJacVersionFromDistInfo(jacPath);
+    if (distInfo) return distInfo;
+
+    const devVersion = await getJacVersionFromDevSource(jacPath);
+    if (devVersion) return devVersion;
+
+    const hash16 = await getBinaryHash16(jacPath);
+    if (hash16) {
+        const memo = await memoLoad();
+        if (memo[hash16]) return memo[hash16];
+    }
+
+    const version = (await getJacVersionFromCache(jacPath, hash16)) ?? (await getJacVersionFromBinary(jacPath));
+    if (version && hash16) await memoStore(hash16, version);
+    return version;
 }
 
 // Compares two semver strings. Returns positive if a > b, negative if a < b, 0 if equal.

--- a/src/utils/envVersion.ts
+++ b/src/utils/envVersion.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import * as os from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { createHash } from 'crypto';
 
 const execFileAsync = promisify(execFile);
 
@@ -132,7 +131,7 @@ async function getVersionFromSiteDir(siteDir: string): Promise<string | undefine
 // Two cache dir formats:
 //   New (≥0.30.3): <hash16>-<pathhash16>  (33 chars) — per binary path
 //   Old (≤0.30.2): <hash16>               (16 chars) — per payload, shared
-async function getJacVersionFromCache(jacPath: string, hash16: string | undefined): Promise<string | undefined> {
+async function getJacVersionFromCache(hash16: string | undefined): Promise<string | undefined> {
     const rtDir = path.join(jacCacheBase(), 'jac', 'rt');
     let hashDirs: string[];
     try { hashDirs = await fs.readdir(rtDir); }
@@ -143,7 +142,8 @@ async function getJacVersionFromCache(jacPath: string, hash16: string | undefine
     const HEX16 = /^[0-9a-f]{16}$/;
     const newFormatDirs = hashDirs.filter(d => d.length === RT_KEY_LEN && d[16] === '-');
 
-    // 1. hash16 (payload identity) match — exact and path-independent
+    // 1. hash16 (payload identity) match — rtKey() always derives the dir name from the
+    // same trailer hash16, so any binary with a new-format dir has a readable hash16.
     if (hash16) {
         for (const dir of newFormatDirs.filter(d => d.startsWith(hash16 + '-'))) {
             const ver = await getVersionFromSiteDir(path.join(rtDir, dir, 'site'));
@@ -151,22 +151,7 @@ async function getJacVersionFromCache(jacPath: string, hash16: string | undefine
         }
     }
 
-    // 2. pathhash match — covers binaries whose trailer we couldn't read
-    let resolvedPath: string;
-    try { resolvedPath = await fs.realpath(jacPath); } catch { resolvedPath = jacPath; }
-
-    const pathHashFor = (p: string) => createHash('sha256').update(p).digest('hex').slice(0, 16);
-
-    let matchingDirs = newFormatDirs.filter(d => d.slice(17) === pathHashFor(resolvedPath));
-    if (matchingDirs.length === 0 && resolvedPath !== jacPath) {
-        matchingDirs = newFormatDirs.filter(d => d.slice(17) === pathHashFor(jacPath));
-    }
-    for (const dir of matchingDirs) {
-        const ver = await getVersionFromSiteDir(path.join(rtDir, dir, 'site'));
-        if (ver) return ver;
-    }
-
-    // 3. Old format — only safe when no new-format dirs exist (avoids stale post-GC reads)
+    // 2. Old format — only safe when no new-format dirs exist (avoids stale post-GC reads)
     const oldFormatDirs = hashDirs.filter(d => d.length === 16 && HEX16.test(d));
     if (newFormatDirs.length === 0 && oldFormatDirs.length > 0) {
         const versions: string[] = [];
@@ -203,7 +188,7 @@ export async function getJacVersion(jacPath: string): Promise<string | undefined
         if (memo[hash16]) return memo[hash16];
     }
 
-    const version = (await getJacVersionFromCache(jacPath, hash16)) ?? (await getJacVersionFromBinary(jacPath));
+    const version = (await getJacVersionFromCache(hash16)) ?? (await getJacVersionFromBinary(jacPath));
     if (version && hash16) await memoStore(hash16, version);
     return version;
 }

--- a/src/utils/envVersion.ts
+++ b/src/utils/envVersion.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import * as os from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 
@@ -45,7 +46,26 @@ async function getJacVersionFromDistInfo(jacPath: string): Promise<string | unde
     } catch { return undefined; }
 }
 
-// Authoritative: ask the specific binary directly. Works for any install (single binary or venv).
+// Middle path: scan ~/.cache/jac/rt/*/site/jaclang-*.dist-info — no subprocess, works for binary installs.
+async function getJacVersionFromCache(): Promise<string | undefined> {
+    const cacheBase = process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache');
+    const rtDir = path.join(cacheBase, 'jac', 'rt');
+    let hashDirs: string[];
+    try { hashDirs = await fs.readdir(rtDir); }
+    catch { return undefined; }
+    const versions: string[] = [];
+    for (const hashDir of hashDirs) {
+        let entries: string[];
+        try { entries = await fs.readdir(path.join(rtDir, hashDir, 'site')); }
+        catch { continue; }
+        const distInfo = entries.find(e => e.startsWith('jaclang-') && e.endsWith('.dist-info'));
+        if (distInfo) versions.push(distInfo.slice('jaclang-'.length, -'.dist-info'.length));
+    }
+    const unique = [...new Set(versions)];
+    return unique.length === 1 ? unique[0] : undefined;
+}
+
+// Last resort: ask the specific binary directly (~1.8s, may be slow on cold cache).
 async function getJacVersionFromBinary(jacPath: string): Promise<string | undefined> {
     try {
         const { stdout, stderr } = await execFileAsync(jacPath, ['--version'], { timeout: 5000 });
@@ -53,10 +73,9 @@ async function getJacVersionFromBinary(jacPath: string): Promise<string | undefi
     } catch { return undefined; }
 }
 
-// Resolve the version for THIS jacPath. Per-env dist-info first (fast, no subprocess),
-// then the binary itself. Both are keyed on jacPath so each env reports its own version.
+// dist-info (venvs) → cache scan (binary install, no subprocess) → subprocess (last resort).
 export async function getJacVersion(jacPath: string): Promise<string | undefined> {
-    return (await getJacVersionFromDistInfo(jacPath)) ?? (await getJacVersionFromBinary(jacPath));
+    return (await getJacVersionFromDistInfo(jacPath)) ?? (await getJacVersionFromCache()) ?? (await getJacVersionFromBinary(jacPath));
 }
 
 // Compares two semver strings. Returns positive if a > b, negative if a < b, 0 if equal.


### PR DESCRIPTION
## What changed and why

Five bugs found after binary install support landed:

1. **QuickPick opened slowly** — every click on the status bar ran `jac --version` (~1.8s) just to show the current version in the title. Fixed by reading the already-cached `this.jacVersion` instead.

2. **jac's runtime cache can't serve multiple binaries** — each jac binary's gcStale wipes the other binaries' cache dirs in `~/.cache/jac/rt/` on every run. With 2+ jac installs (e.g. a release binary + a dev build), the cache only ever holds ONE binary's version — the other always fell through to a subprocess. Fixed with a persistent version memo owned by the extension (`~/.cache/jac-vscode/versions.json`), keyed by the binary's hash16 — a payload content hash read from the binary's 80-byte trailer in ~0ms. Content-derived key ⇒ entries never go stale; a replaced binary gets a new hash16 and re-learns once.

3. **Cold `jac --version` exceeded the timeout** — a binary whose cache was GC'd re-extracts its full runtime payload on next run (10s+ measured), but the subprocess timeout was 5s → killed → no version shown at all, plus a 5s freeze on every QuickPick open. Timeout raised to 30s; the result lands in the memo so this cost is paid at most once per binary.

4. **Dev builds showed a stale version** — a dev build (`zig-out/bin/jac`) reports the live `<repo>/jac.toml` version at runtime, but its cache dist-info holds the build-time version (e.g. binary says 0.30.5, cache says 0.30.3). Fixed by reading `jac.toml` directly for binaries under `zig-out/bin/` — instant and always matches `jac --version`.

5. **Dev builds not detected / duplicate entries** — `zig-out/bin/jac` never appeared in the picker unless the user edited PATH; `build_install.sh --dev` symlinks made the same binary show twice; `.jac/venv/bin/jac` (plugin venv symlink) showed as a phantom entry. All three fixed.

---

## What was broken before

| Situation | Before | After |
|---|---|---|
| Clicking status bar to open QuickPick | ❌ ~1.8s delay | ✅ Opens instantly |
| Version with 2+ jac binaries installed | ❌ One binary always fell to subprocess (jac cache GC war) | ✅ Persistent memo, ~2ms for all |
| Version after jac cache GC'd (cold binary) | ❌ Subprocess killed at 5s → no version shown | ✅ Memo hit ~2ms; first-ever learn gets 30s |
| Dev build version | ❌ Stale build-time version (or none) | ✅ Live `jac.toml` version |
| `zig-out/bin/jac` detection | ❌ Not detected without PATH edit | ✅ Auto-detected up to 2 levels deep |
| `--dev` symlink / `.jac` plugin venv | ❌ Duplicate & phantom picker entries | ✅ Deduplicated / skipped |

---

## Files changed

**`src/environment/manager.ts`**
- QuickPick title uses `this.jacVersion` (cached at startup) instead of awaiting `getJacVersion()` before `show()`

**`src/utils/envVersion.ts`**
- Version resolution order: dist-info (venvs) → live `jac.toml` (dev builds) → persistent memo → jac runtime cache → subprocess (result memoized)
- `getBinaryHash16()`: reads the JACBIN01 trailer (last 80 bytes) for the payload content hash — the memo key and an exact, path-independent runtime-cache match
- Persistent memo at `~/.cache/jac-vscode/versions.json` — survives VS Code restarts and jac cache GC
- `getJacVersionFromDevSource()`: binaries under `zig-out/bin/` read live `<repo>/jac.toml`
- Runtime cache scan handles both dir formats: new (≥0.30.3) `<hash16>-<pathhash16>` per binary; old (≤0.30.2) `<hash16>` shared — old format only trusted when no new-format dirs exist
- Subprocess timeout 5s → 30s (cold extraction takes 10s+; runs at most once per binary)

**`src/utils/envDetection.ts`**
- `walkForVenvs`: skips `.jac/` dirs (project plugin venvs created by `jac install`, not standalone installs)
- `findInWorkspace`: scans `zig-out/bin/jac` up to two levels deep (workspace may be `jaseci/jac/`, `jaseci/`, or a parent folder)
- `discoverJacEnvironments`: deduplicates by realpath so `--dev` symlinks don't produce two entries for one binary

---

## Validation

- Two binaries installed (release `~/.local/bin/jac` 0.30.3 + dev `zig-out/bin/jac` 0.30.5): both resolve in 1–2ms
- Deliberately triggered jac's cache GC (ran one binary to wipe the other's cache): wiped binary still resolves in 2ms from the memo
- Dev build correctly shows live `jac.toml` version (0.30.5) instead of stale build-time dist-info (0.30.3)
- `tsc` clean
